### PR TITLE
Remove streaming of diagnostics

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -235,13 +235,11 @@ class PublishDiagnosticsParams {
   @NonNull TextDocumentIdentifier textDocument
   @NonNull BuildTargetIdentifier buildTarget
   @NonNull List<Diagnostic> diagnostics
-  @NonNull Boolean reset
   String originId
-  new(@NonNull TextDocumentIdentifier textDocument, @NonNull BuildTargetIdentifier buildTarget, @NonNull List<Diagnostic> diagnostics, @NonNull Boolean reset) {
+  new(@NonNull TextDocumentIdentifier textDocument, @NonNull BuildTargetIdentifier buildTarget, @NonNull List<Diagnostic> diagnostics) {
     this.textDocument = textDocument
     this.buildTarget = buildTarget
     this.diagnostics = diagnostics
-    this.reset = reset
   }
 }
 

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/PublishDiagnosticsParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/PublishDiagnosticsParams.java
@@ -19,16 +19,12 @@ public class PublishDiagnosticsParams {
   @NonNull
   private List<Diagnostic> diagnostics;
   
-  @NonNull
-  private Boolean reset;
-  
   private String originId;
   
-  public PublishDiagnosticsParams(@NonNull final TextDocumentIdentifier textDocument, @NonNull final BuildTargetIdentifier buildTarget, @NonNull final List<Diagnostic> diagnostics, @NonNull final Boolean reset) {
+  public PublishDiagnosticsParams(@NonNull final TextDocumentIdentifier textDocument, @NonNull final BuildTargetIdentifier buildTarget, @NonNull final List<Diagnostic> diagnostics) {
     this.textDocument = textDocument;
     this.buildTarget = buildTarget;
     this.diagnostics = diagnostics;
-    this.reset = reset;
   }
   
   @Pure
@@ -62,16 +58,6 @@ public class PublishDiagnosticsParams {
   }
   
   @Pure
-  @NonNull
-  public Boolean getReset() {
-    return this.reset;
-  }
-  
-  public void setReset(@NonNull final Boolean reset) {
-    this.reset = reset;
-  }
-  
-  @Pure
   public String getOriginId() {
     return this.originId;
   }
@@ -87,7 +73,6 @@ public class PublishDiagnosticsParams {
     b.add("textDocument", this.textDocument);
     b.add("buildTarget", this.buildTarget);
     b.add("diagnostics", this.diagnostics);
-    b.add("reset", this.reset);
     b.add("originId", this.originId);
     return b.toString();
   }
@@ -117,11 +102,6 @@ public class PublishDiagnosticsParams {
         return false;
     } else if (!this.diagnostics.equals(other.diagnostics))
       return false;
-    if (this.reset == null) {
-      if (other.reset != null)
-        return false;
-    } else if (!this.reset.equals(other.reset))
-      return false;
     if (this.originId == null) {
       if (other.originId != null)
         return false;
@@ -138,7 +118,6 @@ public class PublishDiagnosticsParams {
     result = prime * result + ((this.textDocument== null) ? 0 : this.textDocument.hashCode());
     result = prime * result + ((this.buildTarget== null) ? 0 : this.buildTarget.hashCode());
     result = prime * result + ((this.diagnostics== null) ? 0 : this.diagnostics.hashCode());
-    result = prime * result + ((this.reset== null) ? 0 : this.reset.hashCode());
     return prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
   }
 }

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -229,8 +229,7 @@ object DiagnosticSeverity {
     textDocument: TextDocumentIdentifier,
     buildTarget: BuildTargetIdentifier,
     originId: Option[String],
-    diagnostics: List[Diagnostic],
-    reset: Boolean
+    diagnostics: List[Diagnostic]
 )
 
 @JsonCodec final case class WorkspaceBuildTargetsRequest()

--- a/docs/bsp.md
+++ b/docs/bsp.md
@@ -600,24 +600,16 @@ trait PublishDiagnosticsParams {
   
   /** The diagnostics to be published by the client. */
   def diagnostics: List[Diagnostic]
-
-  /** Whether the client should clear the previous diagnostics
-    * mapped to the same `textDocument` and `buildTarget`. */
-  def reset: Boolean
 }
 ```
 
 where `Diagnostic` is defined as it is in LSP.
 
-When `reset` is true, the client must clean all previous diagnostics
-associated with the same `textDocument` and `buildTarget` and set instead the
-diagnostics in the request. This is the same behaviour as
-`PublishDiagnosticsParams` in the LSP. When `reset` is false, the diagnostics
-are added to the last active diagnostics, allowing build tools to stream
-diagnostics to the client.
+A publish diagnostic notification overrides all previous diagnostics
+associated with the `textDocument` and `buildTarget` with the new received
+diagnostics. It follows the same behavior as `PublishDiagnosticsParams` in LSP.
 
-It is the server's responsibility to manage the lifetime of the diagnostics by
-using the appropriate value in the `reset` field. Clients generate new
+Clients generate new
 diagnostics by calling any BSP endpoint that triggers a `buildTarget/compile`,
 such as `buildTarget/compile`, `buildTarget/test` and `buildTarget/run`.
 

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/AbstractMockServer.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/AbstractMockServer.scala
@@ -66,10 +66,9 @@ abstract class AbstractMockServer {
   }
 
   def publishDiagnostics(doc: TextDocumentIdentifier, target: BuildTargetIdentifier, diagnostics: List[Diagnostic],
-                        origin: Option[String] = None,
-                        reset: Boolean = false): Future[Ack] = {
+                        origin: Option[String] = None): Future[Ack] = {
     endpoints.Build.publishDiagnostics.notify(
-      PublishDiagnosticsParams(doc, target, origin, diagnostics, reset)
+      PublishDiagnosticsParams(doc, target, origin, diagnostics)
     )
   }
 

--- a/tests/src/test/scala/tests/SerializationSuite.scala
+++ b/tests/src/test/scala/tests/SerializationSuite.scala
@@ -57,8 +57,7 @@ class SerializationSuite extends FunSuite {
       bsp4s.TextDocumentIdentifier(bsp4s.Uri(textDocument)),
       bsp4s.BuildTargetIdentifier(bsp4s.Uri(buildTarget)),
       Some("origin"),
-      List(diagnostic1),
-      reset = false
+      List(diagnostic1)
     )
 
     val bsp4sJson = bsp4sValue.asJson.toString()
@@ -68,7 +67,6 @@ class SerializationSuite extends FunSuite {
 
     assert(bsp4jValue.getBuildTarget.getUri == bsp4sValue.buildTarget.uri.value)
     assert(bsp4jValue.getOriginId == bsp4sValue.originId.get)
-    assert(bsp4jValue.getReset == bsp4sValue.reset)
     assert(bsp4jValue.getTextDocument.getUri == bsp4sValue.textDocument.uri.value)
     assert(bsp4jValue.getDiagnostics.get(0).getMessage == bsp4sValue.diagnostics.head.message)
     assert(bsp4jValue.getDiagnostics.get(0).getSeverity.getValue == bsp4sValue.diagnostics.head.severity.get.id)


### PR DESCRIPTION
In previous versions of BSP, we added a field `reset: Boolean` to
diagnostics that would allow the server to stream diagnostics to the
client, instead of sending them all at once.

The motivation for this feature is that the end user would get more
instant feedback than with the batched approach. The way this approach
worked is that the first diagnostic notification for a text document
identifier would have `reset: Boolean = true` and the rest would be set
to `false` preventing the client from clearing all diagnostics in the
same text document.

This commit instead removes this approach. This removal is motivated by
the real-world experience of using this diagnostics publishing strategy
in tools in the Scala ecosystem. There are two main reasons for its
removal:

1. Notifications in JSON-RPC have no ordering so they can arrive to the
client in whatever order they are sent/processed by the OS/client.
Therefore, the approach above could be not setting certain diagnostics
if they are sent before the diagnostic that sets `reset = true`. This
has happened to me several times while using these tools.

2. There are other ways we can provide instant feedback to the client.
Instead of streaming, the server can send small batches of diagnostics
for text document identifiers as the compiler goes through the code
(e.g. every time the compiler finishes a compilation phase).  This comes
at the cost of delivering more notifications to the client and minimizes
issues with race conditions when setting diagnostics.

Therefore, we stay with the LSP approach of sending diagnostics. It's
clearer and simpler for BSP clients.