### PR TITLE
add jvm options to ScalaTestParams

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/ScalaExtension.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/ScalaExtension.xtend
@@ -24,7 +24,17 @@ class ScalaBuildTarget {
 
 @JsonRpcData
 class ScalaTestParams {
-  List<ScalaTestClassesItem> testClasses
+  @NonNull List<ScalaTestClassesItem> testClasses
+  @NonNull List<String> jvmOptions
+
+  new(@NonNull List<ScalaTestClassesItem> testClasses, @NonNull List<String> jvmOptions){
+    this(testClasses)
+    this.jvmOptions = jvmOptions
+  }
+
+  new(@NonNull List<ScalaTestClassesItem> testClasses){
+      this.testClasses = testClasses
+  }
 }
 
 @JsonRpcData

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestParams.java
@@ -2,20 +2,45 @@ package ch.epfl.scala.bsp4j;
 
 import ch.epfl.scala.bsp4j.ScalaTestClassesItem;
 import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 @SuppressWarnings("all")
 public class ScalaTestParams {
+  @NonNull
   private List<ScalaTestClassesItem> testClasses;
   
+  @NonNull
+  private List<String> jvmOptions;
+  
+  public ScalaTestParams(@NonNull final List<ScalaTestClassesItem> testClasses, @NonNull final List<String> jvmOptions) {
+    this(testClasses);
+    this.jvmOptions = jvmOptions;
+  }
+  
+  public ScalaTestParams(@NonNull final List<ScalaTestClassesItem> testClasses) {
+    this.testClasses = testClasses;
+  }
+  
   @Pure
+  @NonNull
   public List<ScalaTestClassesItem> getTestClasses() {
     return this.testClasses;
   }
   
-  public void setTestClasses(final List<ScalaTestClassesItem> testClasses) {
+  public void setTestClasses(@NonNull final List<ScalaTestClassesItem> testClasses) {
     this.testClasses = testClasses;
+  }
+  
+  @Pure
+  @NonNull
+  public List<String> getJvmOptions() {
+    return this.jvmOptions;
+  }
+  
+  public void setJvmOptions(@NonNull final List<String> jvmOptions) {
+    this.jvmOptions = jvmOptions;
   }
   
   @Override
@@ -23,6 +48,7 @@ public class ScalaTestParams {
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("testClasses", this.testClasses);
+    b.add("jvmOptions", this.jvmOptions);
     return b.toString();
   }
   
@@ -41,12 +67,20 @@ public class ScalaTestParams {
         return false;
     } else if (!this.testClasses.equals(other.testClasses))
       return false;
+    if (this.jvmOptions == null) {
+      if (other.jvmOptions != null)
+        return false;
+    } else if (!this.jvmOptions.equals(other.jvmOptions))
+      return false;
     return true;
   }
   
   @Override
   @Pure
   public int hashCode() {
-    return 31 * 1 + ((this.testClasses== null) ? 0 : this.testClasses.hashCode());
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.testClasses== null) ? 0 : this.testClasses.hashCode());
+    return prime * result + ((this.jvmOptions== null) ? 0 : this.jvmOptions.hashCode());
   }
 }

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -560,7 +560,8 @@ object ScalaPlatform {
 )
 
 @JsonCodec final case class ScalaTestParams(
-    testClasses: Option[List[ScalaTestClassesItem]],
+    testClasses: List[ScalaTestClassesItem],
+    jvmOptions: List[String]
 )
 
 // Request: 'buildTarget/scalacOptions', C -> S

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
@@ -389,12 +389,9 @@ trait Bsp4jGenerators {
   } yield new ScalaTestClassesResult(items)
 
   lazy val genScalaTestParams: Gen[ScalaTestParams] = for {
-    items <- genScalaTestClassesItem.list.nullable
-  } yield {
-    val params = new ScalaTestParams()
-    params.setTestClasses(items)
-    params
-  }
+    items <- genScalaTestClassesItem.list
+    jvmOptions <- Gen.identifier.list
+  } yield new ScalaTestParams(items, jvmOptions)
 
   lazy val genShowMessageParams: Gen[ShowMessageParams] = for {
     messageType <- genMessageType

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jShrinkers.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jShrinkers.scala
@@ -422,11 +422,8 @@ trait Bsp4jShrinkers extends UtilShrinkers {
   implicit def shrinkScalaTestParams: Shrink[ScalaTestParams] = Shrink { a =>
     for {
       items <- shrink(a.getTestClasses)
-    } yield {
-      val params = new ScalaTestParams()
-      params.setTestClasses(items)
-      params
-    }
+      jvmOptions <- shrink(a.getJvmOptions)
+    } yield new ScalaTestParams(items, jvmOptions)
   }
 
   implicit def shrinkShowMessageParams: Shrink[ShowMessageParams] = Shrink { a =>


### PR DESCRIPTION
This allows the user to customize the JVM on which the tests are run. Useful when one wants to, for example, attach to this VM to debug the tests.