### PR TITLE
Upgrade lsp4j dependency to v0.8.1 from v0.5.0.

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,285 @@
+# License notice for lsp4j
+
+The bsp4j project contains parts which are derived from
+[lsp4j](https://github.com/eclipse/lsp4j) source code.  We include the text of
+the original license below:
+
+```
+Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following 
+Secondary Licenses when the conditions for such availability set forth 
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.
+```

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -5,6 +5,7 @@ import com.google.gson.annotations.JsonAdapter
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull
 import org.eclipse.lsp4j.generator.JsonRpcData
+import org.eclipse.lsp4j.util.Preconditions
 
 @JsonRpcData
 class TextDocumentIdentifier {

--- a/bsp4j/src/main/java/org/eclipse/lsp4j/util/Preconditions.java
+++ b/bsp4j/src/main/java/org/eclipse/lsp4j/util/Preconditions.java
@@ -1,0 +1,34 @@
+/******************************************************************************
+ * Copyright (c) 2019 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.lsp4j.util;
+
+/**
+ * Utilities for checking method and constructor arguments.
+ */
+public final class Preconditions {
+	
+	private Preconditions() {}
+	
+	private static boolean nullChecks = true;
+	
+	public static void enableNullChecks(boolean enable) {
+		Preconditions.nullChecks = enable;
+	}
+	
+	public static <T> T checkNotNull(T object, String propertyName) {
+		if (nullChecks && object == null) {
+			throw new IllegalArgumentException("Property must not be null: " + propertyName);
+		}
+		return object;
+	}
+
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BspConnectionDetails.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BspConnectionDetails.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -37,7 +38,7 @@ public class BspConnectionDetails {
   }
   
   public void setName(@NonNull final String name) {
-    this.name = name;
+    this.name = Preconditions.checkNotNull(name, "name");
   }
   
   @Pure
@@ -47,7 +48,7 @@ public class BspConnectionDetails {
   }
   
   public void setArgv(@NonNull final List<String> argv) {
-    this.argv = argv;
+    this.argv = Preconditions.checkNotNull(argv, "argv");
   }
   
   @Pure
@@ -57,7 +58,7 @@ public class BspConnectionDetails {
   }
   
   public void setVersion(@NonNull final String version) {
-    this.version = version;
+    this.version = Preconditions.checkNotNull(version, "version");
   }
   
   @Pure
@@ -67,7 +68,7 @@ public class BspConnectionDetails {
   }
   
   public void setBspVersion(@NonNull final String bspVersion) {
-    this.bspVersion = bspVersion;
+    this.bspVersion = Preconditions.checkNotNull(bspVersion, "bspVersion");
   }
   
   @Pure
@@ -77,7 +78,7 @@ public class BspConnectionDetails {
   }
   
   public void setLanguages(@NonNull final List<String> languages) {
-    this.languages = languages;
+    this.languages = Preconditions.checkNotNull(languages, "languages");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildClientCapabilities.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildClientCapabilities.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -21,7 +22,7 @@ public class BuildClientCapabilities {
   }
   
   public void setLanguageIds(@NonNull final List<String> languageIds) {
-    this.languageIds = languageIds;
+    this.languageIds = Preconditions.checkNotNull(languageIds, "languageIds");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTarget.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTarget.java
@@ -6,6 +6,7 @@ import com.google.gson.annotations.JsonAdapter;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -50,7 +51,7 @@ public class BuildTarget {
   }
   
   public void setId(@NonNull final BuildTargetIdentifier id) {
-    this.id = id;
+    this.id = Preconditions.checkNotNull(id, "id");
   }
   
   @Pure
@@ -78,7 +79,7 @@ public class BuildTarget {
   }
   
   public void setTags(@NonNull final List<String> tags) {
-    this.tags = tags;
+    this.tags = Preconditions.checkNotNull(tags, "tags");
   }
   
   @Pure
@@ -88,7 +89,7 @@ public class BuildTarget {
   }
   
   public void setLanguageIds(@NonNull final List<String> languageIds) {
-    this.languageIds = languageIds;
+    this.languageIds = Preconditions.checkNotNull(languageIds, "languageIds");
   }
   
   @Pure
@@ -98,7 +99,7 @@ public class BuildTarget {
   }
   
   public void setDependencies(@NonNull final List<BuildTargetIdentifier> dependencies) {
-    this.dependencies = dependencies;
+    this.dependencies = Preconditions.checkNotNull(dependencies, "dependencies");
   }
   
   @Pure
@@ -108,7 +109,7 @@ public class BuildTarget {
   }
   
   public void setCapabilities(@NonNull final BuildTargetCapabilities capabilities) {
-    this.capabilities = capabilities;
+    this.capabilities = Preconditions.checkNotNull(capabilities, "capabilities");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetCapabilities.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetCapabilities.java
@@ -1,6 +1,7 @@
 package ch.epfl.scala.bsp4j;
 
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -28,7 +29,7 @@ public class BuildTargetCapabilities {
   }
   
   public void setCanCompile(@NonNull final Boolean canCompile) {
-    this.canCompile = canCompile;
+    this.canCompile = Preconditions.checkNotNull(canCompile, "canCompile");
   }
   
   @Pure
@@ -38,7 +39,7 @@ public class BuildTargetCapabilities {
   }
   
   public void setCanTest(@NonNull final Boolean canTest) {
-    this.canTest = canTest;
+    this.canTest = Preconditions.checkNotNull(canTest, "canTest");
   }
   
   @Pure
@@ -48,7 +49,7 @@ public class BuildTargetCapabilities {
   }
   
   public void setCanRun(@NonNull final Boolean canRun) {
-    this.canRun = canRun;
+    this.canRun = Preconditions.checkNotNull(canRun, "canRun");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetEvent.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetEvent.java
@@ -5,6 +5,7 @@ import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import com.google.gson.annotations.JsonAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -29,7 +30,7 @@ public class BuildTargetEvent {
   }
   
   public void setTarget(@NonNull final BuildTargetIdentifier target) {
-    this.target = target;
+    this.target = Preconditions.checkNotNull(target, "target");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetIdentifier.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetIdentifier.java
@@ -1,6 +1,7 @@
 package ch.epfl.scala.bsp4j;
 
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -20,7 +21,7 @@ public class BuildTargetIdentifier {
   }
   
   public void setUri(@NonNull final String uri) {
-    this.uri = uri;
+    this.uri = Preconditions.checkNotNull(uri, "uri");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CleanCacheParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CleanCacheParams.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -22,7 +23,7 @@ public class CleanCacheParams {
   }
   
   public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
-    this.targets = targets;
+    this.targets = Preconditions.checkNotNull(targets, "targets");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CleanCacheResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CleanCacheResult.java
@@ -1,6 +1,7 @@
 package ch.epfl.scala.bsp4j;
 
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -32,7 +33,7 @@ public class CleanCacheResult {
   }
   
   public void setCleaned(@NonNull final Boolean cleaned) {
-    this.cleaned = cleaned;
+    this.cleaned = Preconditions.checkNotNull(cleaned, "cleaned");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileParams.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -26,7 +27,7 @@ public class CompileParams {
   }
   
   public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
-    this.targets = targets;
+    this.targets = Preconditions.checkNotNull(targets, "targets");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileProvider.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileProvider.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -21,7 +22,7 @@ public class CompileProvider {
   }
   
   public void setLanguageIds(@NonNull final List<String> languageIds) {
-    this.languageIds = languageIds;
+    this.languageIds = Preconditions.checkNotNull(languageIds, "languageIds");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileReport.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileReport.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -33,7 +34,7 @@ public class CompileReport {
   }
   
   public void setTarget(@NonNull final BuildTargetIdentifier target) {
-    this.target = target;
+    this.target = Preconditions.checkNotNull(target, "target");
   }
   
   @Pure
@@ -52,7 +53,7 @@ public class CompileReport {
   }
   
   public void setErrors(@NonNull final Integer errors) {
-    this.errors = errors;
+    this.errors = Preconditions.checkNotNull(errors, "errors");
   }
   
   @Pure
@@ -62,7 +63,7 @@ public class CompileReport {
   }
   
   public void setWarnings(@NonNull final Integer warnings) {
-    this.warnings = warnings;
+    this.warnings = Preconditions.checkNotNull(warnings, "warnings");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileResult.java
@@ -4,6 +4,7 @@ import ch.epfl.scala.bsp4j.StatusCode;
 import com.google.gson.annotations.JsonAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -57,7 +58,7 @@ public class CompileResult {
   }
   
   public void setStatusCode(@NonNull final StatusCode statusCode) {
-    this.statusCode = statusCode;
+    this.statusCode = Preconditions.checkNotNull(statusCode, "statusCode");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileTask.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileTask.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -21,7 +22,7 @@ public class CompileTask {
   }
   
   public void setTarget(@NonNull final BuildTargetIdentifier target) {
-    this.target = target;
+    this.target = Preconditions.checkNotNull(target, "target");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DebugSessionAddress.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DebugSessionAddress.java
@@ -1,6 +1,7 @@
 package ch.epfl.scala.bsp4j;
 
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -20,7 +21,7 @@ public class DebugSessionAddress {
   }
   
   public void setUri(@NonNull final String uri) {
-    this.uri = uri;
+    this.uri = Preconditions.checkNotNull(uri, "uri");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DebugSessionParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DebugSessionParams.java
@@ -5,6 +5,7 @@ import com.google.gson.annotations.JsonAdapter;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -32,7 +33,7 @@ public class DebugSessionParams {
   }
   
   public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
-    this.targets = targets;
+    this.targets = Preconditions.checkNotNull(targets, "targets");
   }
   
   @Pure
@@ -42,7 +43,7 @@ public class DebugSessionParams {
   }
   
   public void setDataKind(@NonNull final String dataKind) {
-    this.dataKind = dataKind;
+    this.dataKind = Preconditions.checkNotNull(dataKind, "dataKind");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencySourcesItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencySourcesItem.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -26,7 +27,7 @@ public class DependencySourcesItem {
   }
   
   public void setTarget(@NonNull final BuildTargetIdentifier target) {
-    this.target = target;
+    this.target = Preconditions.checkNotNull(target, "target");
   }
   
   @Pure
@@ -36,7 +37,7 @@ public class DependencySourcesItem {
   }
   
   public void setSources(@NonNull final List<String> sources) {
-    this.sources = sources;
+    this.sources = Preconditions.checkNotNull(sources, "sources");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencySourcesParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencySourcesParams.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -22,7 +23,7 @@ public class DependencySourcesParams {
   }
   
   public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
-    this.targets = targets;
+    this.targets = Preconditions.checkNotNull(targets, "targets");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencySourcesResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencySourcesResult.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.DependencySourcesItem;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -22,7 +23,7 @@ public class DependencySourcesResult {
   }
   
   public void setItems(@NonNull final List<DependencySourcesItem> items) {
-    this.items = items;
+    this.items = Preconditions.checkNotNull(items, "items");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Diagnostic.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Diagnostic.java
@@ -4,6 +4,7 @@ import ch.epfl.scala.bsp4j.DiagnosticRelatedInformation;
 import ch.epfl.scala.bsp4j.DiagnosticSeverity;
 import ch.epfl.scala.bsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -35,7 +36,7 @@ public class Diagnostic {
   }
   
   public void setRange(@NonNull final Range range) {
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   @Pure
@@ -72,7 +73,7 @@ public class Diagnostic {
   }
   
   public void setMessage(@NonNull final String message) {
-    this.message = message;
+    this.message = Preconditions.checkNotNull(message, "message");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DiagnosticRelatedInformation.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DiagnosticRelatedInformation.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import ch.epfl.scala.bsp4j.Location;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -25,7 +26,7 @@ public class DiagnosticRelatedInformation {
   }
   
   public void setLocation(@NonNull final Location location) {
-    this.location = location;
+    this.location = Preconditions.checkNotNull(location, "location");
   }
   
   @Pure
@@ -35,7 +36,7 @@ public class DiagnosticRelatedInformation {
   }
   
   public void setMessage(@NonNull final String message) {
-    this.message = message;
+    this.message = Preconditions.checkNotNull(message, "message");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DidChangeBuildTarget.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DidChangeBuildTarget.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.BuildTargetEvent;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -22,7 +23,7 @@ public class DidChangeBuildTarget {
   }
   
   public void setChanges(@NonNull final List<BuildTargetEvent> changes) {
-    this.changes = changes;
+    this.changes = Preconditions.checkNotNull(changes, "changes");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/InitializeBuildParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/InitializeBuildParams.java
@@ -4,6 +4,7 @@ import ch.epfl.scala.bsp4j.BuildClientCapabilities;
 import com.google.gson.annotations.JsonAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -42,7 +43,7 @@ public class InitializeBuildParams {
   }
   
   public void setRootUri(@NonNull final String rootUri) {
-    this.rootUri = rootUri;
+    this.rootUri = Preconditions.checkNotNull(rootUri, "rootUri");
   }
   
   @Pure
@@ -52,7 +53,7 @@ public class InitializeBuildParams {
   }
   
   public void setDisplayName(@NonNull final String displayName) {
-    this.displayName = displayName;
+    this.displayName = Preconditions.checkNotNull(displayName, "displayName");
   }
   
   @Pure
@@ -62,7 +63,7 @@ public class InitializeBuildParams {
   }
   
   public void setVersion(@NonNull final String version) {
-    this.version = version;
+    this.version = Preconditions.checkNotNull(version, "version");
   }
   
   @Pure
@@ -72,7 +73,7 @@ public class InitializeBuildParams {
   }
   
   public void setBspVersion(@NonNull final String bspVersion) {
-    this.bspVersion = bspVersion;
+    this.bspVersion = Preconditions.checkNotNull(bspVersion, "bspVersion");
   }
   
   @Pure
@@ -82,7 +83,7 @@ public class InitializeBuildParams {
   }
   
   public void setCapabilities(@NonNull final BuildClientCapabilities capabilities) {
-    this.capabilities = capabilities;
+    this.capabilities = Preconditions.checkNotNull(capabilities, "capabilities");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/InitializeBuildResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/InitializeBuildResult.java
@@ -4,6 +4,7 @@ import ch.epfl.scala.bsp4j.BuildServerCapabilities;
 import com.google.gson.annotations.JsonAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -38,7 +39,7 @@ public class InitializeBuildResult {
   }
   
   public void setDisplayName(@NonNull final String displayName) {
-    this.displayName = displayName;
+    this.displayName = Preconditions.checkNotNull(displayName, "displayName");
   }
   
   @Pure
@@ -48,7 +49,7 @@ public class InitializeBuildResult {
   }
   
   public void setVersion(@NonNull final String version) {
-    this.version = version;
+    this.version = Preconditions.checkNotNull(version, "version");
   }
   
   @Pure
@@ -58,7 +59,7 @@ public class InitializeBuildResult {
   }
   
   public void setBspVersion(@NonNull final String bspVersion) {
-    this.bspVersion = bspVersion;
+    this.bspVersion = Preconditions.checkNotNull(bspVersion, "bspVersion");
   }
   
   @Pure
@@ -68,7 +69,7 @@ public class InitializeBuildResult {
   }
   
   public void setCapabilities(@NonNull final BuildServerCapabilities capabilities) {
-    this.capabilities = capabilities;
+    this.capabilities = Preconditions.checkNotNull(capabilities, "capabilities");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/InverseSourcesParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/InverseSourcesParams.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import ch.epfl.scala.bsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -21,7 +22,7 @@ public class InverseSourcesParams {
   }
   
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/InverseSourcesResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/InverseSourcesResult.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -22,7 +23,7 @@ public class InverseSourcesResult {
   }
   
   public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
-    this.targets = targets;
+    this.targets = Preconditions.checkNotNull(targets, "targets");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Location.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Location.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import ch.epfl.scala.bsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -25,7 +26,7 @@ public class Location {
   }
   
   public void setUri(@NonNull final String uri) {
-    this.uri = uri;
+    this.uri = Preconditions.checkNotNull(uri, "uri");
   }
   
   @Pure
@@ -35,7 +36,7 @@ public class Location {
   }
   
   public void setRange(@NonNull final Range range) {
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/LogMessageParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/LogMessageParams.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.MessageType;
 import ch.epfl.scala.bsp4j.TaskId;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -30,7 +31,7 @@ public class LogMessageParams {
   }
   
   public void setType(@NonNull final MessageType type) {
-    this.type = type;
+    this.type = Preconditions.checkNotNull(type, "type");
   }
   
   @Pure
@@ -58,7 +59,7 @@ public class LogMessageParams {
   }
   
   public void setMessage(@NonNull final String message) {
-    this.message = message;
+    this.message = Preconditions.checkNotNull(message, "message");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Position.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Position.java
@@ -1,6 +1,7 @@
 package ch.epfl.scala.bsp4j;
 
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -24,7 +25,7 @@ public class Position {
   }
   
   public void setLine(@NonNull final Integer line) {
-    this.line = line;
+    this.line = Preconditions.checkNotNull(line, "line");
   }
   
   @Pure
@@ -34,7 +35,7 @@ public class Position {
   }
   
   public void setCharacter(@NonNull final Integer character) {
-    this.character = character;
+    this.character = Preconditions.checkNotNull(character, "character");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/PublishDiagnosticsParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/PublishDiagnosticsParams.java
@@ -5,6 +5,7 @@ import ch.epfl.scala.bsp4j.Diagnostic;
 import ch.epfl.scala.bsp4j.TextDocumentIdentifier;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -38,7 +39,7 @@ public class PublishDiagnosticsParams {
   }
   
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   @Pure
@@ -48,7 +49,7 @@ public class PublishDiagnosticsParams {
   }
   
   public void setBuildTarget(@NonNull final BuildTargetIdentifier buildTarget) {
-    this.buildTarget = buildTarget;
+    this.buildTarget = Preconditions.checkNotNull(buildTarget, "buildTarget");
   }
   
   @Pure
@@ -58,7 +59,7 @@ public class PublishDiagnosticsParams {
   }
   
   public void setDiagnostics(@NonNull final List<Diagnostic> diagnostics) {
-    this.diagnostics = diagnostics;
+    this.diagnostics = Preconditions.checkNotNull(diagnostics, "diagnostics");
   }
   
   @Pure
@@ -68,7 +69,7 @@ public class PublishDiagnosticsParams {
   }
   
   public void setReset(@NonNull final Boolean reset) {
-    this.reset = reset;
+    this.reset = Preconditions.checkNotNull(reset, "reset");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Range.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Range.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import ch.epfl.scala.bsp4j.Position;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -25,7 +26,7 @@ public class Range {
   }
   
   public void setStart(@NonNull final Position start) {
-    this.start = start;
+    this.start = Preconditions.checkNotNull(start, "start");
   }
   
   @Pure
@@ -35,7 +36,7 @@ public class Range {
   }
   
   public void setEnd(@NonNull final Position end) {
-    this.end = end;
+    this.end = Preconditions.checkNotNull(end, "end");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ResourcesItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ResourcesItem.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -26,7 +27,7 @@ public class ResourcesItem {
   }
   
   public void setTarget(@NonNull final BuildTargetIdentifier target) {
-    this.target = target;
+    this.target = Preconditions.checkNotNull(target, "target");
   }
   
   @Pure
@@ -36,7 +37,7 @@ public class ResourcesItem {
   }
   
   public void setResources(@NonNull final List<String> resources) {
-    this.resources = resources;
+    this.resources = Preconditions.checkNotNull(resources, "resources");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ResourcesParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ResourcesParams.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -22,7 +23,7 @@ public class ResourcesParams {
   }
   
   public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
-    this.targets = targets;
+    this.targets = Preconditions.checkNotNull(targets, "targets");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ResourcesResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ResourcesResult.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.ResourcesItem;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -22,7 +23,7 @@ public class ResourcesResult {
   }
   
   public void setItems(@NonNull final List<ResourcesItem> items) {
-    this.items = items;
+    this.items = Preconditions.checkNotNull(items, "items");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/RunParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/RunParams.java
@@ -5,6 +5,7 @@ import com.google.gson.annotations.JsonAdapter;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -33,7 +34,7 @@ public class RunParams {
   }
   
   public void setTarget(@NonNull final BuildTargetIdentifier target) {
-    this.target = target;
+    this.target = Preconditions.checkNotNull(target, "target");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/RunProvider.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/RunProvider.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -21,7 +22,7 @@ public class RunProvider {
   }
   
   public void setLanguageIds(@NonNull final List<String> languageIds) {
-    this.languageIds = languageIds;
+    this.languageIds = Preconditions.checkNotNull(languageIds, "languageIds");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/RunResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/RunResult.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import ch.epfl.scala.bsp4j.StatusCode;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -32,7 +33,7 @@ public class RunResult {
   }
   
   public void setStatusCode(@NonNull final StatusCode statusCode) {
-    this.statusCode = statusCode;
+    this.statusCode = Preconditions.checkNotNull(statusCode, "statusCode");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/SbtBuildTarget.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/SbtBuildTarget.java
@@ -4,6 +4,7 @@ import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import ch.epfl.scala.bsp4j.ScalaBuildTarget;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -40,7 +41,7 @@ public class SbtBuildTarget {
   }
   
   public void setSbtVersion(@NonNull final String sbtVersion) {
-    this.sbtVersion = sbtVersion;
+    this.sbtVersion = Preconditions.checkNotNull(sbtVersion, "sbtVersion");
   }
   
   @Pure
@@ -50,7 +51,7 @@ public class SbtBuildTarget {
   }
   
   public void setAutoImports(@NonNull final List<String> autoImports) {
-    this.autoImports = autoImports;
+    this.autoImports = Preconditions.checkNotNull(autoImports, "autoImports");
   }
   
   @Pure
@@ -60,7 +61,7 @@ public class SbtBuildTarget {
   }
   
   public void setClasspath(@NonNull final List<String> classpath) {
-    this.classpath = classpath;
+    this.classpath = Preconditions.checkNotNull(classpath, "classpath");
   }
   
   @Pure
@@ -70,7 +71,7 @@ public class SbtBuildTarget {
   }
   
   public void setScalaBuildTarget(@NonNull final ScalaBuildTarget scalaBuildTarget) {
-    this.scalaBuildTarget = scalaBuildTarget;
+    this.scalaBuildTarget = Preconditions.checkNotNull(scalaBuildTarget, "scalaBuildTarget");
   }
   
   @Pure
@@ -89,7 +90,7 @@ public class SbtBuildTarget {
   }
   
   public void setChildren(@NonNull final List<BuildTargetIdentifier> children) {
-    this.children = children;
+    this.children = Preconditions.checkNotNull(children, "children");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaBuildTarget.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaBuildTarget.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.ScalaPlatform;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -38,7 +39,7 @@ public class ScalaBuildTarget {
   }
   
   public void setScalaOrganization(@NonNull final String scalaOrganization) {
-    this.scalaOrganization = scalaOrganization;
+    this.scalaOrganization = Preconditions.checkNotNull(scalaOrganization, "scalaOrganization");
   }
   
   @Pure
@@ -48,7 +49,7 @@ public class ScalaBuildTarget {
   }
   
   public void setScalaVersion(@NonNull final String scalaVersion) {
-    this.scalaVersion = scalaVersion;
+    this.scalaVersion = Preconditions.checkNotNull(scalaVersion, "scalaVersion");
   }
   
   @Pure
@@ -58,7 +59,7 @@ public class ScalaBuildTarget {
   }
   
   public void setScalaBinaryVersion(@NonNull final String scalaBinaryVersion) {
-    this.scalaBinaryVersion = scalaBinaryVersion;
+    this.scalaBinaryVersion = Preconditions.checkNotNull(scalaBinaryVersion, "scalaBinaryVersion");
   }
   
   @Pure
@@ -68,7 +69,7 @@ public class ScalaBuildTarget {
   }
   
   public void setPlatform(@NonNull final ScalaPlatform platform) {
-    this.platform = platform;
+    this.platform = Preconditions.checkNotNull(platform, "platform");
   }
   
   @Pure
@@ -78,7 +79,7 @@ public class ScalaBuildTarget {
   }
   
   public void setJars(@NonNull final List<String> jars) {
-    this.jars = jars;
+    this.jars = Preconditions.checkNotNull(jars, "jars");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaMainClass.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaMainClass.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import com.google.gson.annotations.SerializedName;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -31,7 +32,7 @@ public class ScalaMainClass {
   }
   
   public void setClassName(@NonNull final String className) {
-    this.className = className;
+    this.className = Preconditions.checkNotNull(className, "className");
   }
   
   @Pure
@@ -41,7 +42,7 @@ public class ScalaMainClass {
   }
   
   public void setArguments(@NonNull final List<String> arguments) {
-    this.arguments = arguments;
+    this.arguments = Preconditions.checkNotNull(arguments, "arguments");
   }
   
   @Pure
@@ -51,7 +52,7 @@ public class ScalaMainClass {
   }
   
   public void setJvmOptions(@NonNull final List<String> jvmOptions) {
-    this.jvmOptions = jvmOptions;
+    this.jvmOptions = Preconditions.checkNotNull(jvmOptions, "jvmOptions");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaMainClassesItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaMainClassesItem.java
@@ -4,6 +4,7 @@ import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import ch.epfl.scala.bsp4j.ScalaMainClass;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -27,7 +28,7 @@ public class ScalaMainClassesItem {
   }
   
   public void setTarget(@NonNull final BuildTargetIdentifier target) {
-    this.target = target;
+    this.target = Preconditions.checkNotNull(target, "target");
   }
   
   @Pure
@@ -37,7 +38,7 @@ public class ScalaMainClassesItem {
   }
   
   public void setClasses(@NonNull final List<ScalaMainClass> classes) {
-    this.classes = classes;
+    this.classes = Preconditions.checkNotNull(classes, "classes");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaMainClassesParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaMainClassesParams.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -24,7 +25,7 @@ public class ScalaMainClassesParams {
   }
   
   public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
-    this.targets = targets;
+    this.targets = Preconditions.checkNotNull(targets, "targets");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaMainClassesResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaMainClassesResult.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.ScalaMainClassesItem;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -22,7 +23,7 @@ public class ScalaMainClassesResult {
   }
   
   public void setItems(@NonNull final List<ScalaMainClassesItem> items) {
-    this.items = items;
+    this.items = Preconditions.checkNotNull(items, "items");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestClassesItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestClassesItem.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -26,7 +27,7 @@ public class ScalaTestClassesItem {
   }
   
   public void setTarget(@NonNull final BuildTargetIdentifier target) {
-    this.target = target;
+    this.target = Preconditions.checkNotNull(target, "target");
   }
   
   @Pure
@@ -36,7 +37,7 @@ public class ScalaTestClassesItem {
   }
   
   public void setClasses(@NonNull final List<String> classes) {
-    this.classes = classes;
+    this.classes = Preconditions.checkNotNull(classes, "classes");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestClassesParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestClassesParams.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -24,7 +25,7 @@ public class ScalaTestClassesParams {
   }
   
   public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
-    this.targets = targets;
+    this.targets = Preconditions.checkNotNull(targets, "targets");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestClassesResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestClassesResult.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.ScalaTestClassesItem;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -22,7 +23,7 @@ public class ScalaTestClassesResult {
   }
   
   public void setItems(@NonNull final List<ScalaTestClassesItem> items) {
-    this.items = items;
+    this.items = Preconditions.checkNotNull(items, "items");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalacOptionsItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalacOptionsItem.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -34,7 +35,7 @@ public class ScalacOptionsItem {
   }
   
   public void setTarget(@NonNull final BuildTargetIdentifier target) {
-    this.target = target;
+    this.target = Preconditions.checkNotNull(target, "target");
   }
   
   @Pure
@@ -44,7 +45,7 @@ public class ScalacOptionsItem {
   }
   
   public void setOptions(@NonNull final List<String> options) {
-    this.options = options;
+    this.options = Preconditions.checkNotNull(options, "options");
   }
   
   @Pure
@@ -54,7 +55,7 @@ public class ScalacOptionsItem {
   }
   
   public void setClasspath(@NonNull final List<String> classpath) {
-    this.classpath = classpath;
+    this.classpath = Preconditions.checkNotNull(classpath, "classpath");
   }
   
   @Pure
@@ -64,7 +65,7 @@ public class ScalacOptionsItem {
   }
   
   public void setClassDirectory(@NonNull final String classDirectory) {
-    this.classDirectory = classDirectory;
+    this.classDirectory = Preconditions.checkNotNull(classDirectory, "classDirectory");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalacOptionsParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalacOptionsParams.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -22,7 +23,7 @@ public class ScalacOptionsParams {
   }
   
   public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
-    this.targets = targets;
+    this.targets = Preconditions.checkNotNull(targets, "targets");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalacOptionsResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalacOptionsResult.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.ScalacOptionsItem;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -22,7 +23,7 @@ public class ScalacOptionsResult {
   }
   
   public void setItems(@NonNull final List<ScalacOptionsItem> items) {
-    this.items = items;
+    this.items = Preconditions.checkNotNull(items, "items");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ShowMessageParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ShowMessageParams.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.MessageType;
 import ch.epfl.scala.bsp4j.TaskId;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -30,7 +31,7 @@ public class ShowMessageParams {
   }
   
   public void setType(@NonNull final MessageType type) {
-    this.type = type;
+    this.type = Preconditions.checkNotNull(type, "type");
   }
   
   @Pure
@@ -58,7 +59,7 @@ public class ShowMessageParams {
   }
   
   public void setMessage(@NonNull final String message) {
-    this.message = message;
+    this.message = Preconditions.checkNotNull(message, "message");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/SourceItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/SourceItem.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import ch.epfl.scala.bsp4j.SourceItemKind;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -29,7 +30,7 @@ public class SourceItem {
   }
   
   public void setUri(@NonNull final String uri) {
-    this.uri = uri;
+    this.uri = Preconditions.checkNotNull(uri, "uri");
   }
   
   @Pure
@@ -39,7 +40,7 @@ public class SourceItem {
   }
   
   public void setKind(@NonNull final SourceItemKind kind) {
-    this.kind = kind;
+    this.kind = Preconditions.checkNotNull(kind, "kind");
   }
   
   @Pure
@@ -49,7 +50,7 @@ public class SourceItem {
   }
   
   public void setGenerated(@NonNull final Boolean generated) {
-    this.generated = generated;
+    this.generated = Preconditions.checkNotNull(generated, "generated");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/SourcesItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/SourcesItem.java
@@ -4,6 +4,7 @@ import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import ch.epfl.scala.bsp4j.SourceItem;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -27,7 +28,7 @@ public class SourcesItem {
   }
   
   public void setTarget(@NonNull final BuildTargetIdentifier target) {
-    this.target = target;
+    this.target = Preconditions.checkNotNull(target, "target");
   }
   
   @Pure
@@ -37,7 +38,7 @@ public class SourcesItem {
   }
   
   public void setSources(@NonNull final List<SourceItem> sources) {
-    this.sources = sources;
+    this.sources = Preconditions.checkNotNull(sources, "sources");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/SourcesParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/SourcesParams.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -22,7 +23,7 @@ public class SourcesParams {
   }
   
   public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
-    this.targets = targets;
+    this.targets = Preconditions.checkNotNull(targets, "targets");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/SourcesResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/SourcesResult.java
@@ -3,6 +3,7 @@ package ch.epfl.scala.bsp4j;
 import ch.epfl.scala.bsp4j.SourcesItem;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -22,7 +23,7 @@ public class SourcesResult {
   }
   
   public void setItems(@NonNull final List<SourcesItem> items) {
-    this.items = items;
+    this.items = Preconditions.checkNotNull(items, "items");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TaskFinishParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TaskFinishParams.java
@@ -5,6 +5,7 @@ import ch.epfl.scala.bsp4j.TaskId;
 import com.google.gson.annotations.JsonAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -37,7 +38,7 @@ public class TaskFinishParams {
   }
   
   public void setTaskId(@NonNull final TaskId taskId) {
-    this.taskId = taskId;
+    this.taskId = Preconditions.checkNotNull(taskId, "taskId");
   }
   
   @Pure
@@ -65,7 +66,7 @@ public class TaskFinishParams {
   }
   
   public void setStatus(@NonNull final StatusCode status) {
-    this.status = status;
+    this.status = Preconditions.checkNotNull(status, "status");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TaskId.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TaskId.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -23,7 +24,7 @@ public class TaskId {
   }
   
   public void setId(@NonNull final String id) {
-    this.id = id;
+    this.id = Preconditions.checkNotNull(id, "id");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TaskProgressParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TaskProgressParams.java
@@ -4,6 +4,7 @@ import ch.epfl.scala.bsp4j.TaskId;
 import com.google.gson.annotations.JsonAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -38,7 +39,7 @@ public class TaskProgressParams {
   }
   
   public void setTaskId(@NonNull final TaskId taskId) {
-    this.taskId = taskId;
+    this.taskId = Preconditions.checkNotNull(taskId, "taskId");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TaskStartParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TaskStartParams.java
@@ -4,6 +4,7 @@ import ch.epfl.scala.bsp4j.TaskId;
 import com.google.gson.annotations.JsonAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -32,7 +33,7 @@ public class TaskStartParams {
   }
   
   public void setTaskId(@NonNull final TaskId taskId) {
-    this.taskId = taskId;
+    this.taskId = Preconditions.checkNotNull(taskId, "taskId");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestFinish.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestFinish.java
@@ -5,6 +5,7 @@ import ch.epfl.scala.bsp4j.TestStatus;
 import com.google.gson.annotations.JsonAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -37,7 +38,7 @@ public class TestFinish {
   }
   
   public void setDisplayName(@NonNull final String displayName) {
-    this.displayName = displayName;
+    this.displayName = Preconditions.checkNotNull(displayName, "displayName");
   }
   
   @Pure
@@ -56,7 +57,7 @@ public class TestFinish {
   }
   
   public void setStatus(@NonNull final TestStatus status) {
-    this.status = status;
+    this.status = Preconditions.checkNotNull(status, "status");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestParams.java
@@ -5,6 +5,7 @@ import com.google.gson.annotations.JsonAdapter;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -33,7 +34,7 @@ public class TestParams {
   }
   
   public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
-    this.targets = targets;
+    this.targets = Preconditions.checkNotNull(targets, "targets");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestProvider.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestProvider.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -21,7 +22,7 @@ public class TestProvider {
   }
   
   public void setLanguageIds(@NonNull final List<String> languageIds) {
-    this.languageIds = languageIds;
+    this.languageIds = Preconditions.checkNotNull(languageIds, "languageIds");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestReport.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestReport.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -45,7 +46,7 @@ public class TestReport {
   }
   
   public void setTarget(@NonNull final BuildTargetIdentifier target) {
-    this.target = target;
+    this.target = Preconditions.checkNotNull(target, "target");
   }
   
   @Pure
@@ -64,7 +65,7 @@ public class TestReport {
   }
   
   public void setPassed(@NonNull final Integer passed) {
-    this.passed = passed;
+    this.passed = Preconditions.checkNotNull(passed, "passed");
   }
   
   @Pure
@@ -74,7 +75,7 @@ public class TestReport {
   }
   
   public void setFailed(@NonNull final Integer failed) {
-    this.failed = failed;
+    this.failed = Preconditions.checkNotNull(failed, "failed");
   }
   
   @Pure
@@ -84,7 +85,7 @@ public class TestReport {
   }
   
   public void setIgnored(@NonNull final Integer ignored) {
-    this.ignored = ignored;
+    this.ignored = Preconditions.checkNotNull(ignored, "ignored");
   }
   
   @Pure
@@ -94,7 +95,7 @@ public class TestReport {
   }
   
   public void setCancelled(@NonNull final Integer cancelled) {
-    this.cancelled = cancelled;
+    this.cancelled = Preconditions.checkNotNull(cancelled, "cancelled");
   }
   
   @Pure
@@ -104,7 +105,7 @@ public class TestReport {
   }
   
   public void setSkipped(@NonNull final Integer skipped) {
-    this.skipped = skipped;
+    this.skipped = Preconditions.checkNotNull(skipped, "skipped");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestResult.java
@@ -4,6 +4,7 @@ import ch.epfl.scala.bsp4j.StatusCode;
 import com.google.gson.annotations.JsonAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -57,7 +58,7 @@ public class TestResult {
   }
   
   public void setStatusCode(@NonNull final StatusCode statusCode) {
-    this.statusCode = statusCode;
+    this.statusCode = Preconditions.checkNotNull(statusCode, "statusCode");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestStart.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestStart.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import ch.epfl.scala.bsp4j.Location;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -23,7 +24,7 @@ public class TestStart {
   }
   
   public void setDisplayName(@NonNull final String displayName) {
-    this.displayName = displayName;
+    this.displayName = Preconditions.checkNotNull(displayName, "displayName");
   }
   
   @Pure

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestTask.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestTask.java
@@ -2,6 +2,7 @@ package ch.epfl.scala.bsp4j;
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -21,7 +22,7 @@ public class TestTask {
   }
   
   public void setTarget(@NonNull final BuildTargetIdentifier target) {
-    this.target = target;
+    this.target = Preconditions.checkNotNull(target, "target");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TextDocumentIdentifier.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TextDocumentIdentifier.java
@@ -1,6 +1,7 @@
 package ch.epfl.scala.bsp4j;
 
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -20,7 +21,7 @@ public class TextDocumentIdentifier {
   }
   
   public void setUri(@NonNull final String uri) {
-    this.uri = uri;
+    this.uri = Preconditions.checkNotNull(uri, "uri");
   }
   
   @Override

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 inThisBuild(
   List(
+    scalaVersion := "2.12.10",
     scmInfo := Some(
       ScmInfo(
         browseUrl = url("https://github.com/scalacenter/bsp"),
@@ -74,8 +75,8 @@ lazy val bsp4j = project
     },
     unmanagedSourceDirectories.in(Compile) += sourceDirectory.in(Compile).value / "xtend-gen",
     libraryDependencies ++= List(
-      "org.eclipse.lsp4j" % "org.eclipse.lsp4j.generator" % "0.5.0",
-      "org.eclipse.lsp4j" % "org.eclipse.lsp4j.jsonrpc" % "0.5.0"
+      "org.eclipse.lsp4j" % "org.eclipse.lsp4j.generator" % "0.8.1",
+      "org.eclipse.lsp4j" % "org.eclipse.lsp4j.jsonrpc" % "0.8.1"
     )
   )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.2


### PR DESCRIPTION
The latest version seems to enforce the `@NotNull` annotation at
runtime. The annotation is verified with a `Preconditions.java` class
that is only included in the lsp4j module, which bsp4js doesn't depend
on, so the source code of `Preconditions.java` was copied verbatim into
this codebase along with an accompanying license.