### PR TITLE
Add packagePrefix to SourceItem

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -293,6 +293,7 @@ class SourcesResult {
 class SourcesItem {
   @NonNull BuildTargetIdentifier target
   @NonNull List<SourceItem> sources
+  List<String> roots
   new(@NonNull BuildTargetIdentifier target, @NonNull List<SourceItem> sources) {
     this.target = target
     this.sources = sources

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/SourcesItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/SourcesItem.java
@@ -16,6 +16,8 @@ public class SourcesItem {
   @NonNull
   private List<SourceItem> sources;
   
+  private List<String> roots;
+  
   public SourcesItem(@NonNull final BuildTargetIdentifier target, @NonNull final List<SourceItem> sources) {
     this.target = target;
     this.sources = sources;
@@ -41,12 +43,22 @@ public class SourcesItem {
     this.sources = Preconditions.checkNotNull(sources, "sources");
   }
   
+  @Pure
+  public List<String> getRoots() {
+    return this.roots;
+  }
+  
+  public void setRoots(final List<String> roots) {
+    this.roots = roots;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("target", this.target);
     b.add("sources", this.sources);
+    b.add("roots", this.roots);
     return b.toString();
   }
   
@@ -70,6 +82,11 @@ public class SourcesItem {
         return false;
     } else if (!this.sources.equals(other.sources))
       return false;
+    if (this.roots == null) {
+      if (other.roots != null)
+        return false;
+    } else if (!this.roots.equals(other.roots))
+      return false;
     return true;
   }
   
@@ -79,6 +96,7 @@ public class SourcesItem {
     final int prime = 31;
     int result = 1;
     result = prime * result + ((this.target== null) ? 0 : this.target.hashCode());
-    return prime * result + ((this.sources== null) ? 0 : this.sources.hashCode());
+    result = prime * result + ((this.sources== null) ? 0 : this.sources.hashCode());
+    return prime * result + ((this.roots== null) ? 0 : this.roots.hashCode());
   }
 }

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -285,7 +285,8 @@ case object BuildTargetEventKind {
 )
 @JsonCodec final case class SourcesItem(
     target: BuildTargetIdentifier,
-    sources: List[SourceItem]
+    sources: List[SourceItem],
+    roots: Option[List[Uri]]
 )
 @JsonCodec final case class SourceItem(
     uri: Uri,

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -667,6 +667,11 @@ export interface SourcesItem {
   target: BuildTargetIdentifer;
   /** The text documents or and directories that belong to this build target. */
   sources: SourceItem[];
+  /** The root directories from where source files should be relativized.
+   * 
+   * Example: ["file://Users/name/dev/metals/src/main/scala"]
+   */
+  roots?: Uri[]; 
 }
 
 export interface SourceItem {

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
@@ -420,7 +420,12 @@ trait Bsp4jGenerators {
   lazy val genSourcesItem: Gen[SourcesItem] = for {
     target <- genBuildTargetIdentifier
     sources <- genSourceItem.list
-  } yield new SourcesItem(target, sources)
+    roots <- genFileUriString.list.nullable
+  } yield {
+    val item = new SourcesItem(target, sources)
+    item.setRoots(roots)
+    item
+  }
 
   lazy val genSourcesParams: Gen[SourcesParams] = for {
     targets <- genBuildTargetIdentifier.list

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
@@ -78,11 +78,11 @@ class HappyMockServer(base: File, val logger: Logger, implicit val client: Langu
   def sources(params: SourcesParams): BspResponse[SourcesResult] = {
     val sourceDir1 = target1.uri.toPath.resolve("src/")
     val item1 = SourceItem(asDirUri(sourceDir1), SourceItemKind.Directory, true)
-    val items1 = SourcesItem(target1, List(item1))
+    val items1 = SourcesItem(target1, List(item1), roots = None)
 
     val sourceDir2 = target2.uri.toPath.resolve("src-gen/")
     val item2 = SourceItem(asDirUri(sourceDir2), SourceItemKind.Directory, true)
-    val items2 = SourcesItem(target2, List(item2))
+    val items2 = SourcesItem(target2, List(item2), roots = None)
 
     val sourceDir3 = target3.uri.toPath.resolve("sauce/")
     val sourceFile1 = target3.uri.toPath.resolve("somewhere/sourcefile1")
@@ -92,7 +92,7 @@ class HappyMockServer(base: File, val logger: Logger, implicit val client: Langu
     val item31 = SourceItem(Uri(sourceFile1.toUri), SourceItemKind.File, false)
     val item32 = SourceItem(Uri(sourceFile2.toUri), SourceItemKind.File, false)
     val item33 = SourceItem(Uri(sourceFile3.toUri), SourceItemKind.File, true)
-    val items3 = SourcesItem(target3, List(item3Dir, item31, item32, item33))
+    val items3 = SourcesItem(target3, List(item3Dir, item31, item32, item33), roots = None)
 
     val result = SourcesResult(List(items1, items2, items3))
 


### PR DESCRIPTION
A source set in Intellij has a property called packagePrefix so that if the source root is not located at root of package namespace it is know which package it belongs to.
For example:
for file `src/test/Test.scala` with content 
```
package test
class Test
```
If the source set directory is `/src/test`, we should set package prefix to `test`, otherwise Intellij would think that `test.Test` class is actually `_root_.Test`.

Related PRs for integration:
https://github.com/scalacenter/bloop/pull/1183
https://github.com/scalameta/metals/pull/1470
https://github.com/JetBrains/intellij-scala/pull/503