### PR TITLE
Welcome Tomasz and Lukasz to the team!

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,8 @@ Read the specification [here](docs/specification.md).
 
 The current maintainers (people who can merge pull requests) are:
 
-* Justin Kaeser - [@jastice](https://github.com/jastice)
-* Ólafur Páll Geirsson - [@olafurpg](https://github.com/olafurpg)
 * Jorge Vicente Cantero - [@jvican](https://github.com/jvican)
+* Justin Kaeser - [@jastice](https://github.com/jastice)
+* Łukasz Wawrzyk - [@lukaszwawrzyk](https://github.com/lukaszwawrzyk)
+* Ólafur Páll Geirsson - [@olafurpg](https://github.com/olafurpg)
+* Tomasz Pasternak - [@tpasternak](https://github.com/tpasternak)


### PR DESCRIPTION
Tomasz and Lukasz are engineers at VirtusLab who have recently
contributed nice improvements to the BSP specifications along with
server/client implementation in Bloop, Metals and IntelliJ.  I'd like to
welcome them to the team to recognize their valuable contributions and so
they can merge PRs, help manage the issue tracker and trigger new
releases.

