### PR TITLE
Add new `buildTarget/jvmRunEnvironment` endpoint

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/JvmBuildServer.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/JvmBuildServer.java
@@ -5,6 +5,9 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import java.util.concurrent.CompletableFuture;
 
 public interface JvmBuildServer {
+    @JsonRequest("buildTarget/jvmRunEnvironment")
+    CompletableFuture<JvmRunEnvironmentResult> jvmRunEnvironment(JvmRunEnvironmentParams params);
+
     @JsonRequest("buildTarget/jvmTestEnvironment")
     CompletableFuture<JvmTestEnvironmentResult> jvmTestEnvironment(JvmTestEnvironmentParams params);
 }

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/JvmExtension.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/JvmExtension.xtend
@@ -48,3 +48,19 @@ class JvmTestEnvironmentResult {
   }
 }
 
+
+@JsonRpcData
+class JvmRunEnvironmentParams {
+  @NonNull List<BuildTargetIdentifier> targets
+  new(@NonNull List<BuildTargetIdentifier> targets) {
+    this.targets = targets
+  }
+}
+
+@JsonRpcData
+class JvmRunEnvironmentResult {
+  @NonNull List<JvmEnvironmentItem> items
+  new(@NonNull List<JvmEnvironmentItem> items) {
+    this.items = items
+  }
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -125,6 +125,7 @@ class BuildServerCapabilities {
   Boolean dependencySourcesProvider
   Boolean resourcesProvider
   Boolean buildTargetChangedProvider
+  Boolean jvmRunEnvironmentProvider
   Boolean jvmTestEnvironmentProvider
 }
 

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildServerCapabilities.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildServerCapabilities.java
@@ -22,6 +22,8 @@ public class BuildServerCapabilities {
   
   private Boolean buildTargetChangedProvider;
   
+  private Boolean jvmRunEnvironmentProvider;
+  
   private Boolean jvmTestEnvironmentProvider;
   
   @Pure
@@ -88,6 +90,15 @@ public class BuildServerCapabilities {
   }
   
   @Pure
+  public Boolean getJvmRunEnvironmentProvider() {
+    return this.jvmRunEnvironmentProvider;
+  }
+  
+  public void setJvmRunEnvironmentProvider(final Boolean jvmRunEnvironmentProvider) {
+    this.jvmRunEnvironmentProvider = jvmRunEnvironmentProvider;
+  }
+  
+  @Pure
   public Boolean getJvmTestEnvironmentProvider() {
     return this.jvmTestEnvironmentProvider;
   }
@@ -107,6 +118,7 @@ public class BuildServerCapabilities {
     b.add("dependencySourcesProvider", this.dependencySourcesProvider);
     b.add("resourcesProvider", this.resourcesProvider);
     b.add("buildTargetChangedProvider", this.buildTargetChangedProvider);
+    b.add("jvmRunEnvironmentProvider", this.jvmRunEnvironmentProvider);
     b.add("jvmTestEnvironmentProvider", this.jvmTestEnvironmentProvider);
     return b.toString();
   }
@@ -156,6 +168,11 @@ public class BuildServerCapabilities {
         return false;
     } else if (!this.buildTargetChangedProvider.equals(other.buildTargetChangedProvider))
       return false;
+    if (this.jvmRunEnvironmentProvider == null) {
+      if (other.jvmRunEnvironmentProvider != null)
+        return false;
+    } else if (!this.jvmRunEnvironmentProvider.equals(other.jvmRunEnvironmentProvider))
+      return false;
     if (this.jvmTestEnvironmentProvider == null) {
       if (other.jvmTestEnvironmentProvider != null)
         return false;
@@ -176,6 +193,7 @@ public class BuildServerCapabilities {
     result = prime * result + ((this.dependencySourcesProvider== null) ? 0 : this.dependencySourcesProvider.hashCode());
     result = prime * result + ((this.resourcesProvider== null) ? 0 : this.resourcesProvider.hashCode());
     result = prime * result + ((this.buildTargetChangedProvider== null) ? 0 : this.buildTargetChangedProvider.hashCode());
+    result = prime * result + ((this.jvmRunEnvironmentProvider== null) ? 0 : this.jvmRunEnvironmentProvider.hashCode());
     return prime * result + ((this.jvmTestEnvironmentProvider== null) ? 0 : this.jvmTestEnvironmentProvider.hashCode());
   }
 }

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JvmRunEnvironmentParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JvmRunEnvironmentParams.java
@@ -1,0 +1,60 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class JvmRunEnvironmentParams {
+  @NonNull
+  private List<BuildTargetIdentifier> targets;
+  
+  public JvmRunEnvironmentParams(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getTargets() {
+    return this.targets;
+  }
+  
+  public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = Preconditions.checkNotNull(targets, "targets");
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    JvmRunEnvironmentParams other = (JvmRunEnvironmentParams) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.targets== null) ? 0 : this.targets.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JvmRunEnvironmentResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JvmRunEnvironmentResult.java
@@ -1,0 +1,60 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.JvmEnvironmentItem;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class JvmRunEnvironmentResult {
+  @NonNull
+  private List<JvmEnvironmentItem> items;
+  
+  public JvmRunEnvironmentResult(@NonNull final List<JvmEnvironmentItem> items) {
+    this.items = items;
+  }
+  
+  @Pure
+  @NonNull
+  public List<JvmEnvironmentItem> getItems() {
+    return this.items;
+  }
+  
+  public void setItems(@NonNull final List<JvmEnvironmentItem> items) {
+    this.items = Preconditions.checkNotNull(items, "items");
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("items", this.items);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    JvmRunEnvironmentResult other = (JvmRunEnvironmentResult) obj;
+    if (this.items == null) {
+      if (other.items != null)
+        return false;
+    } else if (!this.items.equals(other.items))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.items== null) ? 0 : this.items.hashCode());
+  }
+}

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -115,7 +115,8 @@ object BuildTargetDataKind {
     dependencySourcesProvider: Option[Boolean],
     resourcesProvider: Option[Boolean],
     buildTargetChangedProvider: Option[Boolean],
-    jvmTestEnvironmentProvider: Option[Boolean]
+    jvmTestEnvironmentProvider: Option[Boolean],
+    jvmRunEnvironmentProvider: Option[Boolean]
 )
 
 @JsonCodec final case class InitializeBuildResult(
@@ -600,6 +601,15 @@ object TestParamsDataKind {
 
 @JsonCodec final case class JvmTestEnvironmentResult(
     items: List[JvmEnvironmentItem]
+)
+
+@JsonCodec final case class JvmRunEnvironmentParams(
+   targets: List[BuildTargetIdentifier],
+   originId: Option[String]
+)
+
+@JsonCodec final case class JvmRunEnvironmentResult(
+   items: List[JvmEnvironmentItem]
 )
 
 @JsonCodec final case class ScalacOptionsItem(

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
@@ -45,8 +45,12 @@ trait BuildTarget {
   object scalaMainClasses
       extends Endpoint[ScalaMainClassesParams, ScalaMainClassesResult](
         "buildTarget/scalaMainClasses")
-  object jvmTestEnvironment extends Endpoint[JvmTestEnvironmentParams, JvmTestEnvironmentResult]("buildTarget/jvmTestEnvironment")
-
+  object jvmTestEnvironment
+    extends Endpoint[JvmTestEnvironmentParams, JvmTestEnvironmentResult](
+      "buildTarget/jvmTestEnvironment")
+  object jvmRunEnvironment
+    extends Endpoint[JvmRunEnvironmentParams, JvmRunEnvironmentResult](
+      "buildTarget/jvmRunEnvironment")
 }
 
 object Workspace extends Workspace

--- a/docs/extensions/jvm.md
+++ b/docs/extensions/jvm.md
@@ -66,3 +66,38 @@ export interface JvmTestEnvironmentResult{
     environmentVariables: Map<String, String>;
 }
 ```
+
+## Run Environment Request
+
+Similar to `buildTarget/jvmTestEnvironment`, but returns environment
+that should be used for regular exection of main classes, not for testing
+
+- method: `buildTarget/jvmRunEnvironment`
+- params: `JvmRunEnvironmentParams`
+
+```ts
+export interface JvmRunEnvironmentParams(
+    targets: BuildTargetIdentifier[],
+    originId?: String
+)
+```
+
+Response:
+
+- result: `JvmRunEnvironmentResult`, defined as follows
+- error: JSON-RPC code and message set in case an exception happens during the
+  request.
+
+```ts
+export interface JvmEnvironmentItem{
+    target: BuildTargetIdentifier;
+    classpath: Uri[];
+    jvmOptions: String[];
+}
+
+export interface JvmRunEnvironmentResult{
+    items: JvmEnvironmentItem[];
+    workingDirectory: String;
+    environmentVariables: Map<String, String>;
+}
+```

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jArbitrary.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jArbitrary.scala
@@ -84,6 +84,8 @@ trait Bsp4jArbitrary {
   implicit val arbJvmEnvironmentItem: Arbitrary[JvmEnvironmentItem] = Arbitrary(genJvmEnvironmentItem)
   implicit val arbTestJvmEnvironmentParams: Arbitrary[JvmTestEnvironmentParams] = Arbitrary(genJvmTestEnvironmentParams)
   implicit val arbTestJvmEnvironmentResult: Arbitrary[JvmTestEnvironmentResult] = Arbitrary(genJvmTestEnvironmentResult)
+  implicit val arbRunJvmEnvironmentParams: Arbitrary[JvmRunEnvironmentParams] = Arbitrary(genJvmRunEnvironmentParams)
+  implicit val arbRunJvmEnvironmentResult: Arbitrary[JvmRunEnvironmentResult] = Arbitrary(genJvmRunEnvironmentResult)
 }
 
 object Bsp4jArbitrary extends Bsp4jArbitrary

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
@@ -618,6 +618,14 @@ trait Bsp4jGenerators {
     items <- genJvmEnvironmentItem.list
   } yield new JvmTestEnvironmentResult(items)
 
+  lazy val genJvmRunEnvironmentParams: Gen[JvmRunEnvironmentParams] = for {
+    targets <- genBuildTargetIdentifier.list
+  } yield new JvmRunEnvironmentParams(targets)
+
+  lazy val genJvmRunEnvironmentResult: Gen[JvmRunEnvironmentResult] = for {
+    items <- genJvmEnvironmentItem.list
+  } yield new JvmRunEnvironmentResult(items)
+
   implicit class GenExt[T](gen: Gen[T]) {
     def optional: Gen[Option[T]] = Gen.option(gen)
     def nullable(implicit ev: Null <:< T): Gen[T] = Gen.option(gen).map(g => g.orNull)

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/AbstractMockServer.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/AbstractMockServer.scala
@@ -30,6 +30,7 @@ abstract class AbstractMockServer {
     .requestAsync(endpoints.BuildTarget.compile)(compile(_))
     .requestAsync(endpoints.BuildTarget.test)(test(_))
     .requestAsync(endpoints.BuildTarget.jvmTestEnvironment)(jvmTestEnvironment(_))
+    .requestAsync(endpoints.BuildTarget.jvmRunEnvironment)(jvmRunEnvironment(_))
     .requestAsync(endpoints.BuildTarget.run)(run(_))
 
   def initialize(params: InitializeBuildParams): BspResponse[InitializeBuildResult]
@@ -42,6 +43,7 @@ abstract class AbstractMockServer {
   def inverseSources(params: InverseSourcesParams): BspResponse[InverseSourcesResult]
   def scalacOptions(params: ScalacOptionsParams): BspResponse[ScalacOptionsResult]
   def jvmTestEnvironment(params: JvmTestEnvironmentParams): BspResponse[JvmTestEnvironmentResult]
+  def jvmRunEnvironment(params: JvmRunEnvironmentParams): BspResponse[JvmRunEnvironmentResult]
   def compile(params: CompileParams): BspResponse[CompileResult]
   def test(params: TestParams): BspResponse[TestResult]
   def run(params: RunParams): BspResponse[RunResult]

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
@@ -199,6 +199,7 @@ class HappyMockServer(base: File, val logger: Logger, implicit val client: Langu
     dependencySourcesProvider = Some(true),
     resourcesProvider = Some(true),
     buildTargetChangedProvider = Some(true),
+    jvmRunEnvironmentProvider = Some(true),
     jvmTestEnvironmentProvider = Some(true)
   )
 
@@ -214,9 +215,21 @@ class HappyMockServer(base: File, val logger: Logger, implicit val client: Langu
     Uri(path.toUri.toString + "/")
 
   override def jvmTestEnvironment(params: JvmTestEnvironmentParams): BspResponse[JvmTestEnvironmentResult] = {
+    val item1: JvmEnvironmentItem = environmentItem(testing = true)
+    val result = JvmTestEnvironmentResult(List(item1))
+    Task(Right(result))
+  }
+
+  override def jvmRunEnvironment(params: JvmRunEnvironmentParams): BspResponse[JvmRunEnvironmentResult] = {
+    val item1: JvmEnvironmentItem = environmentItem(testing = false)
+    val result = JvmRunEnvironmentResult(List(item1))
+    Task(Right(result))
+  }
+
+  private def environmentItem(testing: Boolean) = {
     val classpath = List("scala-library.jar")
     val jvmOptions = List("-Xms256m")
-    val environmentVariables = Map("A"->"a")
+    val environmentVariables = Map("A" -> "a", "TESTING" -> testing.toString)
     val workdir = "/tmp"
     val item1 = JvmEnvironmentItem(
       target = target1,
@@ -225,7 +238,6 @@ class HappyMockServer(base: File, val logger: Logger, implicit val client: Langu
       workingDirectory = workdir,
       environmentVariables = environmentVariables
     )
-    val result = JvmTestEnvironmentResult(List(item1))
-    Task(Right(result))
+    item1
   }
 }

--- a/tests/src/test/scala/tests/SerializationPropertySuite.scala
+++ b/tests/src/test/scala/tests/SerializationPropertySuite.scala
@@ -408,6 +408,16 @@ class SerializationPropertySuite extends FunSuite with GeneratorDrivenPropertyCh
       assertSerializationRoundtrip[bsp4j.JvmTestEnvironmentResult, bsp4s.JvmTestEnvironmentResult](a)
     }
   }
+  test("JvmRunEnvironmentParams") {
+    forAll { a: bsp4j.JvmRunEnvironmentParams =>
+      assertSerializationRoundtrip[bsp4j.JvmRunEnvironmentParams, bsp4s.JvmRunEnvironmentParams](a)
+    }
+  }
+  test("JvmRunEnvironmentResult") {
+    forAll { a: bsp4j.JvmRunEnvironmentResult =>
+      assertSerializationRoundtrip[bsp4j.JvmRunEnvironmentResult, bsp4s.JvmRunEnvironmentResult](a)
+    }
+  }
   test("JvmEnvironmentItem") {
     forAll { a: bsp4j.JvmEnvironmentItem =>
       assertSerializationRoundtrip[bsp4j.JvmEnvironmentItem, bsp4s.JvmEnvironmentItem](a)


### PR DESCRIPTION
Mirror endpoint to jvmTestEnvironment - used to execute main class
from an external tool in the same way as BSP server is doing it

Follow up of https://github.com/build-server-protocol/build-server-protocol/pull/107#discussion_r375346983