### PR TITLE
Fix declared syntax of code listings

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -36,8 +36,8 @@ referred to as the “server”.
 The best way to read this document is by considering it as a wishlist from the
 perspective of an IDE developer.
 
-The code listings in this document are written using Scala syntax. Every data
-strucuture in this document has a direct translation to JSON and Protobuf.
+The code listings in this document are written using TypeScript syntax. Every
+data strucuture in this document has a direct translation to JSON and Protobuf.
 
 ## Status
 


### PR DESCRIPTION
c0a91ef875c2f708d0800e512e9bd4d1f10faec5 changed the language of code samples from Scala to TypeScript, but did not change the sentence that stated the language of code samples.