### PR TITLE
Remove 'k'

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -660,7 +660,7 @@ Response:
 
 ```ts
 export interface SourcesResult {
-  items: SourcesItem[k];
+  items: SourcesItem[];
 }
 
 export interface SourcesItem {


### PR DESCRIPTION
I assume 'k' is a typo, since it's not specified anywhere.