### PR TITLE
Upgrade bsp4s to Monix 3.2.2 and use jsoniter-scala

### DIFF
--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
@@ -1,7 +1,8 @@
 package ch.epfl.scala.bsp
 package endpoints
 
-import scala.meta.jsonrpc.Endpoint
+import jsonrpc4s.Endpoint
+import jsonrpc4s.Endpoint.unitCodec
 
 object Build extends Build
 trait Build {
@@ -33,7 +34,8 @@ trait BuildTarget {
       extends Endpoint[InverseSourcesParams, InverseSourcesResult]("buildTarget/inverseSources")
   object dependencySources
       extends Endpoint[DependencySourcesParams, DependencySourcesResult](
-        "buildTarget/dependencySources")
+        "buildTarget/dependencySources"
+      )
   object resources extends Endpoint[ResourcesParams, ResourcesResult]("buildTarget/resources")
 
   // Scala specific endpoints
@@ -41,23 +43,28 @@ trait BuildTarget {
       extends Endpoint[ScalacOptionsParams, ScalacOptionsResult]("buildTarget/scalacOptions")
   object scalaTestClasses
       extends Endpoint[ScalaTestClassesParams, ScalaTestClassesResult](
-        "buildTarget/scalaTestClasses")
+        "buildTarget/scalaTestClasses"
+      )
   object scalaMainClasses
       extends Endpoint[ScalaMainClassesParams, ScalaMainClassesResult](
-        "buildTarget/scalaMainClasses")
+        "buildTarget/scalaMainClasses"
+      )
   object jvmTestEnvironment
-    extends Endpoint[JvmTestEnvironmentParams, JvmTestEnvironmentResult](
-      "buildTarget/jvmTestEnvironment")
+      extends Endpoint[JvmTestEnvironmentParams, JvmTestEnvironmentResult](
+        "buildTarget/jvmTestEnvironment"
+      )
   object jvmRunEnvironment
-    extends Endpoint[JvmRunEnvironmentParams, JvmRunEnvironmentResult](
-      "buildTarget/jvmRunEnvironment")
+      extends Endpoint[JvmRunEnvironmentParams, JvmRunEnvironmentResult](
+        "buildTarget/jvmRunEnvironment"
+      )
 }
 
 object Workspace extends Workspace
 trait Workspace {
   object buildTargets
       extends Endpoint[WorkspaceBuildTargetsRequest, WorkspaceBuildTargetsResult](
-        "workspace/buildTargets")
+        "workspace/buildTargets"
+      )
 }
 
 object DebugSession extends DebugSession

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,31 @@
-inThisBuild(List(
-  scalaVersion := "2.12.11",
-  organization := "ch.epfl.scala",
-  homepage := Some(url("https://github.com/build-server-protocol/build-server-protocol")),
-  licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
-  developers := List(
-      Developer("olafurpg", "Ólafur Páll Geirsson", "olafurpg@gmail.com", url("https://github.com/olafurpg")),
-      Developer("jvican", "Jorge Vicente Cantero", "jorge@vican.me", url("https://github.com/jvican")),
-      Developer("jastice", "Justin Kaeser", "justin@justinkaeser.com", url("https://github.com/jastice")),
+inThisBuild(
+  List(
+    scalaVersion := "2.12.11",
+    organization := "ch.epfl.scala",
+    homepage := Some(url("https://github.com/build-server-protocol/build-server-protocol")),
+    licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+    developers := List(
+      Developer(
+        "olafurpg",
+        "Ólafur Páll Geirsson",
+        "olafurpg@gmail.com",
+        url("https://github.com/olafurpg")
+      ),
+      Developer(
+        "jvican",
+        "Jorge Vicente Cantero",
+        "jorge@vican.me",
+        url("https://github.com/jvican")
+      ),
+      Developer(
+        "jastice",
+        "Justin Kaeser",
+        "justin@justinkaeser.com",
+        url("https://github.com/jastice")
+      )
+    )
   )
-))
+)
 
 import java.io.File
 import org.eclipse.xtend.core.XtendInjectorSingleton
@@ -27,11 +44,9 @@ lazy val bsp4s = project
   .settings(
     publishArtifact in Test := false,
     sources in (Compile, doc) := Nil,
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
     libraryDependencies ++= List(
-      "io.circe" %% "circe-core" % "0.9.0",
-      "io.circe" %% "circe-derivation" % "0.9.0-M4",
-      "org.scalameta" %% "lsp4s" % "0.2.0"
+      "me.vican.jorge" %% "jsonrpc4s" % "1.0.0+23-a0cabe67",
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.6.0" % Provided
     )
   )
 


### PR DESCRIPTION
Removes dependency on circe, we now only depend on jsoniter-scala itself
for JSON purposes, which is a library with no third-party dependencies.