### PR TITLE
Add extension for java projects

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/JavaBuildServer.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/JavaBuildServer.java
@@ -1,0 +1,10 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface JavaBuildServer {
+    @JsonRequest("buildTarget/javacOptions")
+    CompletableFuture<JavacOptionsResult> buildTargetJavacOptions(JavacOptionsParams params);
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/JavaExtension.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/JavaExtension.xtend
@@ -1,0 +1,37 @@
+package ch.epfl.scala.bsp4j
+
+import java.util.List
+import com.google.gson.annotations.SerializedName
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull
+import org.eclipse.lsp4j.generator.JsonRpcData
+
+@JsonRpcData
+class JavacOptionsParams {
+  @NonNull List<BuildTargetIdentifier> targets
+  new(@NonNull List<BuildTargetIdentifier> targets) {
+    this.targets = targets
+  }
+}
+
+@JsonRpcData
+class JavacOptionsResult {
+  @NonNull List<JavacOptionsItem> items
+  new(@NonNull List<JavacOptionsItem> items) {
+    this.items = items
+  }
+}
+
+@JsonRpcData
+class JavacOptionsItem {
+  @NonNull BuildTargetIdentifier target
+  @NonNull List<String> options
+  @NonNull List<String> classpath
+  @NonNull String classDirectory
+  new(@NonNull BuildTargetIdentifier target, @NonNull List<String> options, @NonNull List<String> classpath,
+      @NonNull String classDirectory) {
+    this.target = target
+    this.options = options
+    this.classpath = classpath
+    this.classDirectory = classDirectory
+   }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JavacOptionsItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JavacOptionsItem.java
@@ -1,0 +1,125 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class JavacOptionsItem {
+  @NonNull
+  private BuildTargetIdentifier target;
+  
+  @NonNull
+  private List<String> options;
+  
+  @NonNull
+  private List<String> classpath;
+  
+  @NonNull
+  private String classDirectory;
+  
+  public JavacOptionsItem(@NonNull final BuildTargetIdentifier target, @NonNull final List<String> options, @NonNull final List<String> classpath, @NonNull final String classDirectory) {
+    this.target = target;
+    this.options = options;
+    this.classpath = classpath;
+    this.classDirectory = classDirectory;
+  }
+  
+  @Pure
+  @NonNull
+  public BuildTargetIdentifier getTarget() {
+    return this.target;
+  }
+  
+  public void setTarget(@NonNull final BuildTargetIdentifier target) {
+    this.target = Preconditions.checkNotNull(target, "target");
+  }
+  
+  @Pure
+  @NonNull
+  public List<String> getOptions() {
+    return this.options;
+  }
+  
+  public void setOptions(@NonNull final List<String> options) {
+    this.options = Preconditions.checkNotNull(options, "options");
+  }
+  
+  @Pure
+  @NonNull
+  public List<String> getClasspath() {
+    return this.classpath;
+  }
+  
+  public void setClasspath(@NonNull final List<String> classpath) {
+    this.classpath = Preconditions.checkNotNull(classpath, "classpath");
+  }
+  
+  @Pure
+  @NonNull
+  public String getClassDirectory() {
+    return this.classDirectory;
+  }
+  
+  public void setClassDirectory(@NonNull final String classDirectory) {
+    this.classDirectory = Preconditions.checkNotNull(classDirectory, "classDirectory");
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("target", this.target);
+    b.add("options", this.options);
+    b.add("classpath", this.classpath);
+    b.add("classDirectory", this.classDirectory);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    JavacOptionsItem other = (JavacOptionsItem) obj;
+    if (this.target == null) {
+      if (other.target != null)
+        return false;
+    } else if (!this.target.equals(other.target))
+      return false;
+    if (this.options == null) {
+      if (other.options != null)
+        return false;
+    } else if (!this.options.equals(other.options))
+      return false;
+    if (this.classpath == null) {
+      if (other.classpath != null)
+        return false;
+    } else if (!this.classpath.equals(other.classpath))
+      return false;
+    if (this.classDirectory == null) {
+      if (other.classDirectory != null)
+        return false;
+    } else if (!this.classDirectory.equals(other.classDirectory))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.target== null) ? 0 : this.target.hashCode());
+    result = prime * result + ((this.options== null) ? 0 : this.options.hashCode());
+    result = prime * result + ((this.classpath== null) ? 0 : this.classpath.hashCode());
+    return prime * result + ((this.classDirectory== null) ? 0 : this.classDirectory.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JavacOptionsParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JavacOptionsParams.java
@@ -1,0 +1,60 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class JavacOptionsParams {
+  @NonNull
+  private List<BuildTargetIdentifier> targets;
+  
+  public JavacOptionsParams(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getTargets() {
+    return this.targets;
+  }
+  
+  public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = Preconditions.checkNotNull(targets, "targets");
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    JavacOptionsParams other = (JavacOptionsParams) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.targets== null) ? 0 : this.targets.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JavacOptionsResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JavacOptionsResult.java
@@ -1,0 +1,60 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.JavacOptionsItem;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class JavacOptionsResult {
+  @NonNull
+  private List<JavacOptionsItem> items;
+  
+  public JavacOptionsResult(@NonNull final List<JavacOptionsItem> items) {
+    this.items = items;
+  }
+  
+  @Pure
+  @NonNull
+  public List<JavacOptionsItem> getItems() {
+    return this.items;
+  }
+  
+  public void setItems(@NonNull final List<JavacOptionsItem> items) {
+    this.items = Preconditions.checkNotNull(items, "items");
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("items", this.items);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    JavacOptionsResult other = (JavacOptionsResult) obj;
+    if (this.items == null) {
+      if (other.items != null)
+        return false;
+    } else if (!this.items.equals(other.items))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.items== null) ? 0 : this.items.hashCode());
+  }
+}

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -689,3 +689,18 @@ object DebugSessionParamsDataKind {
 }
 
 @JsonCodec final case class DebugSessionAddress(uri: String)
+
+@JsonCodec final case class JavacOptionsParams(
+    targets: List[BuildTargetIdentifier]
+)
+
+@JsonCodec final case class JavacOptionsItem(
+    target: BuildTargetIdentifier,
+    options: List[String],
+    classpath: List[Uri],
+    classDirectory: Uri
+)
+
+@JsonCodec final case class JavacOptionsResult(
+    items: List[JavacOptionsItem]
+)

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
@@ -51,6 +51,11 @@ trait BuildTarget {
   object jvmRunEnvironment
     extends Endpoint[JvmRunEnvironmentParams, JvmRunEnvironmentResult](
       "buildTarget/jvmRunEnvironment")
+  // Java specific endpoints
+  object javacOptions
+    extends Endpoint[JavacOptionsParams, JavacOptionsResult](
+      "buildTarget/javacOptions"
+    )
 }
 
 object Workspace extends Workspace

--- a/docs/extensions/java.md
+++ b/docs/extensions/java.md
@@ -1,0 +1,50 @@
+---
+id: java
+title: Java Extension
+sidebar_label: Java
+---
+
+The following section contains Java-specific extensions to the build server
+protocol.
+
+## Javac Options Request
+
+The build target scalac options request is sent from the client to the server to
+query for the list of compiler options necessary to compile in a given list of
+targets.
+
+- method: `buildTarget/javacOptions`
+- params: `JavacOptionsParams`
+
+```ts
+export interface JavacOptionsParams {
+  targets: BuildTargetIdentifier[];
+}
+```
+
+Response:
+
+- result: `JavacOptionsResult`, defined as follows
+
+```ts
+export interface JavacOptionsResult {
+  items: List[JavacOptionsItem];
+}
+
+export interface JavacOptionsItem {
+  target: BuildTargetIdentifier;
+
+  /** Additional arguments to the compiler.
+   * For example, -deprecation. */
+  options: List[String];
+
+  /** The dependency classpath for this target, must be
+   * identical to what is passed as arguments to
+   * the -classpath flag in the command line interface
+   * of javac. */
+  classpath: List[Uri];
+
+  /** The output directory for classfiles produced by this target */
+  classDirectory: Uri;
+}
+```

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jArbitrary.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jArbitrary.scala
@@ -86,6 +86,9 @@ trait Bsp4jArbitrary {
   implicit val arbTestJvmEnvironmentResult: Arbitrary[JvmTestEnvironmentResult] = Arbitrary(genJvmTestEnvironmentResult)
   implicit val arbRunJvmEnvironmentParams: Arbitrary[JvmRunEnvironmentParams] = Arbitrary(genJvmRunEnvironmentParams)
   implicit val arbRunJvmEnvironmentResult: Arbitrary[JvmRunEnvironmentResult] = Arbitrary(genJvmRunEnvironmentResult)
+  implicit val arbJavacOptionsItem: Arbitrary[JavacOptionsItem] = Arbitrary(genJavacOptionsItem)
+  implicit val arbJavacOptionsParams: Arbitrary[JavacOptionsParams] = Arbitrary(genJavacOptionsParams)
+  implicit val arbJavacOptionsResult: Arbitrary[JavacOptionsResult] = Arbitrary(genJavacOptionsResult)
 }
 
 object Bsp4jArbitrary extends Bsp4jArbitrary

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
@@ -631,6 +631,21 @@ trait Bsp4jGenerators {
     items <- genJvmEnvironmentItem.list
   } yield new JvmRunEnvironmentResult(items)
 
+  lazy val genJavacOptionsItem: Gen[JavacOptionsItem] = for {
+    target <- genBuildTargetIdentifier
+    options <- arbitrary[String].list
+    classpath <- genFileUriString.list
+    classDirectory <- genFileUriString
+  } yield new JavacOptionsItem(target, options, classpath, classDirectory)
+
+  lazy val genJavacOptionsParams: Gen[JavacOptionsParams] = for {
+    targets <- genBuildTargetIdentifier.list
+  } yield new JavacOptionsParams(targets)
+
+  lazy val genJavacOptionsResult: Gen[JavacOptionsResult] = for {
+    items <- genJavacOptionsItem.list
+  } yield new JavacOptionsResult(items)
+
   implicit class GenExt[T](gen: Gen[T]) {
     def optional: Gen[Option[T]] = Gen.option(gen)
     def nullable(implicit ev: Null <:< T): Gen[T] = Gen.option(gen).map(g => g.orNull)

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/AbstractMockServer.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/AbstractMockServer.scala
@@ -5,7 +5,7 @@ import com.google.gson.GsonBuilder
 
 import scala.jdk.CollectionConverters._
 
-abstract class AbstractBuildServer extends BuildServer with ScalaBuildServer with JvmBuildServer
+abstract class AbstractBuildServer extends BuildServer with ScalaBuildServer with JvmBuildServer with JavaBuildServer
 
 abstract class AbstractMockServer extends AbstractBuildServer {
   var client: BuildClient

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
@@ -145,6 +145,23 @@ class HappyMockServer(base: File) extends AbstractMockServer {
       Right(result)
     }
 
+  override def buildTargetJavacOptions(
+      params: JavacOptionsParams
+  ): CompletableFuture[JavacOptionsResult] = {
+    handleRequest {
+      val options = List.empty[String].asJava
+      val classpath = List("guava.jar").asJava
+      val item1 =
+        new JavacOptionsItem(targetId1, options, classpath, uriInTarget(targetId1, "out").toString)
+      val item2 =
+        new JavacOptionsItem(targetId2, options, classpath, uriInTarget(targetId2, "out").toString)
+      val item3 =
+        new JavacOptionsItem(targetId3, options, classpath, uriInTarget(targetId3, "out").toString)
+      val result = new JavacOptionsResult(List(item1, item2, item3).asJava)
+      Right(result)
+    }
+  }
+
   override def buildTargetScalaTestClasses(
       params: ScalaTestClassesParams
   ): CompletableFuture[ScalaTestClassesResult] =

--- a/tests/src/test/scala/tests/MockSuite.scala
+++ b/tests/src/test/scala/tests/MockSuite.scala
@@ -14,7 +14,7 @@ import org.scalatest.FunSuite
 
 import scala.collection.JavaConverters._
 
-trait MockBuildServer extends BuildServer with ScalaBuildServer with JvmBuildServer
+trait MockBuildServer extends BuildServer with ScalaBuildServer with JvmBuildServer with JavaBuildServer
 
 class HappyMockSuite extends FunSuite {
 
@@ -83,6 +83,21 @@ class HappyMockSuite extends FunSuite {
       val classpath = item.getClasspath.asScala
       assert(classpath.nonEmpty)
       assert(classpath.exists(_.contains("scala-library")))
+    }
+  }
+
+  def assertJavacOptions(server: MockBuildServer): Unit = {
+    val javacOptionsParams = new JavacOptionsParams(getBuildTargetIds(server))
+    val javacOptionsResult = server.buildTargetJavacOptions(javacOptionsParams).get
+    val javacOptionsItems = javacOptionsResult.getItems.asScala
+    javacOptionsItems.foreach { item =>
+      val options = item.getOptions.asScala
+      assert(options.isEmpty)
+      val uri = item.getTarget.getUri
+      assert(uri.nonEmpty)
+      val classpath = item.getClasspath.asScala
+      assert(classpath.nonEmpty)
+      assert(classpath.exists(_.contains("guava")))
     }
   }
 
@@ -202,6 +217,7 @@ class HappyMockSuite extends FunSuite {
   def assertServerEndpoints(server: MockBuildServer, client: TestBuildClient): Unit = {
     assertWorkspaceBuildTargets(server)
     assertScalacOptions(server)
+    assertJavacOptions(server)
     assertJvmTestEnvironment(server)
     assertJvmRunEnvironment(server)
     assertSources(server, client)

--- a/tests/src/test/scala/tests/SerializationPropertySuite.scala
+++ b/tests/src/test/scala/tests/SerializationPropertySuite.scala
@@ -423,4 +423,19 @@ class SerializationPropertySuite extends FunSuite with GeneratorDrivenPropertyCh
       assertSerializationRoundtrip[bsp4j.JvmEnvironmentItem, bsp4s.JvmEnvironmentItem](a)
     }
   }
+  test("JavacOptionsItem") {
+    forAll { a: bsp4j.JavacOptionsItem =>
+      assertSerializationRoundtrip[bsp4j.JavacOptionsItem, bsp4s.JavacOptionsItem](a)
+    }
+  }
+  test("JavacOptionsParams") {
+    forAll { a: bsp4j.JavacOptionsParams =>
+      assertSerializationRoundtrip[bsp4j.JavacOptionsParams, bsp4s.JavacOptionsParams](a)
+    }
+  }
+  test("JavacOptionsResult") {
+    forAll { a: bsp4j.JavacOptionsResult =>
+      assertSerializationRoundtrip[bsp4j.JavacOptionsResult, bsp4s.JavacOptionsResult](a)
+    }
+  }
 }


### PR DESCRIPTION
Added an extension to the protocol in order to support Java projects. In the light of developments with the implementation of [BSP in bazel](https://github.com/bazelbuild/bazel/pull/11766), there is a need for a better support of java only projects 