### PR TITLE
Change JVM extension to require the JDK to be provided instead of the JRE

### DIFF
--- a/docs/extensions/jvm.md
+++ b/docs/extensions/jvm.md
@@ -16,8 +16,8 @@ the `dataKind` field contains "jvm".
 
 ```ts
 export interface JvmBuildTarget {
-  /** Uri representing absolute path to java home
-   * For example: file:///usr/lib/jvm/java-8-openjdk-amd64/jre */
+  /** Uri representing absolute path to jdk
+   * For example: file:///usr/lib/jvm/java-8-openjdk-amd64 */
   javaHome?: Uri;
 
   /** The java version this target is supposed to use.


### PR DESCRIPTION
It has been discovered that IntelliJ as a client requires the JDK to be provided instead of the JRE. It was also found that servers such as Bloop already provide this information. Since the JRE is insufficient to build the environment, me and @jastice are now proposing a change to the `JVMBuildTarget`, in order for it to return the JDK instead of the JRE