### PR TITLE
Improve Testkit error visibility

### DIFF
--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/TestClient.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/TestClient.scala
@@ -44,9 +44,9 @@ class TestClient(
       Await.result(test, timeoutDuration * 3)
     } catch {
       case _: TimeoutException =>
-        throw new RuntimeException("Failed to complete in time!")
+        throw new OutOfTimeException()
       case e: Throwable =>
-        throw new RuntimeException(s"Test case has failed! Got error: ${e.getCause.getMessage}")
+        throw new TestFailedException(e)
     }
   }
 
@@ -600,6 +600,20 @@ class TestClient(
       session: MockSession
   ): Future[DidChangeBuildTarget] =
     obtainExpectedNotification(buildTargetEventKind, session)
+}
+
+class TestFailedException(e: Throwable) extends Throwable(e){
+  override def printStackTrace(): Unit = {
+    println("Test case failed!")
+    e.printStackTrace()
+  }
+}
+
+class OutOfTimeException extends Throwable{
+  override def printStackTrace(): Unit = {
+    println("Test failed to complete in time!")
+    super.printStackTrace()
+  }
 }
 
 object TestClient {


### PR DESCRIPTION
There were several problems with the current output of errors by the testkit, namely that it didn't allow you to have a proper knowledge as to how they failed in some cases. Therefore I improved how that was portrayed to the user.