### PR TITLE
Add `manual` build target tag

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildTargetTag.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildTargetTag.java
@@ -7,4 +7,5 @@ public class BuildTargetTag {
     public static final String INTEGRATION_TEST = "integration-test";
     public static final String BENCHMARK = "benchmark";
     public static final String NO_IDE = "no-ide";
+    public static final String MANUAL = "manual";
 }

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JavacOptionsParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JavacOptionsParams.java
@@ -1,11 +1,11 @@
 package ch.epfl.scala.bsp4j;
 
-import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
-import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+import java.util.List;
 
 @SuppressWarnings("all")
 public class JavacOptionsParams {

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -55,6 +55,7 @@ object BuildTargetTag {
   val IntegrationTest = "integration-test"
   val Benchmark = "benchmark"
   val NoIDE = "no-ide"
+  val Manual = "manual"
 }
 
 @JsonCodec final case class BuildTarget(

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -184,6 +184,11 @@ export namespace BuildTargetTag {
 
   /** Target should be ignored by IDEs. */
   export const NoIDE = "no-ide";
+
+  /** Actions on the target such as build and test should only be invoked manually
+   * and explicitly. For example, triggering a build on all targets in the workspace
+   * should by default not include this target. */
+  export const Manual = "manual";
 }
 
 export interface BuildTargetCapabilities {

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -187,7 +187,12 @@ export namespace BuildTargetTag {
 
   /** Actions on the target such as build and test should only be invoked manually
    * and explicitly. For example, triggering a build on all targets in the workspace
-   * should by default not include this target. */
+   * should by default not include this target. 
+   *
+   * The original motivation to add the "manual" tag comes from a similar functionality
+   * that exists in Bazel, where targets with this tag have to be specified explicitly
+   * on the command line.
+   */
   export const Manual = "manual";
 }
 

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
@@ -101,7 +101,8 @@ trait Bsp4jGenerators {
     BuildTargetTag.INTEGRATION_TEST,
     BuildTargetTag.LIBRARY,
     BuildTargetTag.NO_IDE,
-    BuildTargetTag.TEST
+    BuildTargetTag.TEST,
+    BuildTargetTag.MANUAL
   )
 
   lazy val genCleanCacheParams: Gen[CleanCacheParams] = for {


### PR DESCRIPTION
Add `manual` build target tag. This is based on the same manual tag in Bazel.

It is used when targets are not supposed to be considered by default when triggering a full workspace build. Instead a build/test/etc action on these targets should be triggered manually by the user.