### PR TITLE
Introduce build/reload request

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
@@ -13,6 +13,9 @@ public interface BuildServer {
     @JsonNotification("build/initialized")
     void onBuildInitialized();
 
+    @JsonRequest("build/reload")
+    CompletableFuture<Object> buildReload();
+
     @JsonRequest("build/shutdown")
     CompletableFuture<Object> buildShutdown();
 
@@ -50,4 +53,3 @@ public interface BuildServer {
 
     }
 }
-

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
@@ -13,9 +13,6 @@ public interface BuildServer {
     @JsonNotification("build/initialized")
     void onBuildInitialized();
 
-    @JsonRequest("build/reload")
-    CompletableFuture<Object> buildReload();
-
     @JsonRequest("build/shutdown")
     CompletableFuture<Object> buildShutdown();
 
@@ -24,6 +21,9 @@ public interface BuildServer {
 
     @JsonRequest("workspace/buildTargets")
     CompletableFuture<WorkspaceBuildTargetsResult> workspaceBuildTargets();
+
+    @JsonRequest("workspace/reload")
+    CompletableFuture<Object> workspaceReload();
 
     @JsonRequest("buildTarget/sources")
     CompletableFuture<SourcesResult> buildTargetSources(SourcesParams params);

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/JavaExtension.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/JavaExtension.xtend
@@ -1,7 +1,6 @@
 package ch.epfl.scala.bsp4j
 
 import java.util.List
-import com.google.gson.annotations.SerializedName
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull
 import org.eclipse.lsp4j.generator.JsonRpcData
 

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -5,7 +5,6 @@ import com.google.gson.annotations.JsonAdapter
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull
 import org.eclipse.lsp4j.generator.JsonRpcData
-import org.eclipse.lsp4j.util.Preconditions
 
 @JsonRpcData
 class TextDocumentIdentifier {
@@ -127,6 +126,7 @@ class BuildServerCapabilities {
   Boolean buildTargetChangedProvider
   Boolean jvmRunEnvironmentProvider
   Boolean jvmTestEnvironmentProvider
+  Boolean canReload
 }
 
 @JsonRpcData

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildServerCapabilities.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildServerCapabilities.java
@@ -26,6 +26,8 @@ public class BuildServerCapabilities {
   
   private Boolean jvmTestEnvironmentProvider;
   
+  private Boolean canReload;
+  
   @Pure
   public CompileProvider getCompileProvider() {
     return this.compileProvider;
@@ -107,6 +109,15 @@ public class BuildServerCapabilities {
     this.jvmTestEnvironmentProvider = jvmTestEnvironmentProvider;
   }
   
+  @Pure
+  public Boolean getCanReload() {
+    return this.canReload;
+  }
+  
+  public void setCanReload(final Boolean canReload) {
+    this.canReload = canReload;
+  }
+  
   @Override
   @Pure
   public String toString() {
@@ -120,6 +131,7 @@ public class BuildServerCapabilities {
     b.add("buildTargetChangedProvider", this.buildTargetChangedProvider);
     b.add("jvmRunEnvironmentProvider", this.jvmRunEnvironmentProvider);
     b.add("jvmTestEnvironmentProvider", this.jvmTestEnvironmentProvider);
+    b.add("canReload", this.canReload);
     return b.toString();
   }
   
@@ -178,6 +190,11 @@ public class BuildServerCapabilities {
         return false;
     } else if (!this.jvmTestEnvironmentProvider.equals(other.jvmTestEnvironmentProvider))
       return false;
+    if (this.canReload == null) {
+      if (other.canReload != null)
+        return false;
+    } else if (!this.canReload.equals(other.canReload))
+      return false;
     return true;
   }
   
@@ -194,6 +211,7 @@ public class BuildServerCapabilities {
     result = prime * result + ((this.resourcesProvider== null) ? 0 : this.resourcesProvider.hashCode());
     result = prime * result + ((this.buildTargetChangedProvider== null) ? 0 : this.buildTargetChangedProvider.hashCode());
     result = prime * result + ((this.jvmRunEnvironmentProvider== null) ? 0 : this.jvmRunEnvironmentProvider.hashCode());
-    return prime * result + ((this.jvmTestEnvironmentProvider== null) ? 0 : this.jvmTestEnvironmentProvider.hashCode());
+    result = prime * result + ((this.jvmTestEnvironmentProvider== null) ? 0 : this.jvmTestEnvironmentProvider.hashCode());
+    return prime * result + ((this.canReload== null) ? 0 : this.canReload.hashCode());
   }
 }

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JavacOptionsParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JavacOptionsParams.java
@@ -1,11 +1,11 @@
 package ch.epfl.scala.bsp4j;
 
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
-
-import java.util.List;
 
 @SuppressWarnings("all")
 public class JavacOptionsParams {

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -2,10 +2,9 @@ package ch.epfl.scala.bsp
 
 import java.net.{URI, URISyntaxException}
 
-import ch.epfl.scala.bsp.BuildTargetEventKind.{Changed, Created, Deleted}
 import io.circe.Decoder.Result
-import io.circe.derivation.JsonCodec
 import io.circe._
+import io.circe.derivation.JsonCodec
 
 final case class Uri private[Uri] (val value: String) {
   def toPath: java.nio.file.Path =
@@ -92,6 +91,8 @@ object BuildTargetDataKind {
     data: Option[Json]
 )
 
+@JsonCodec final case class Reload()
+
 @JsonCodec final case class Shutdown()
 
 @JsonCodec final case class Exit()
@@ -117,7 +118,8 @@ object BuildTargetDataKind {
     resourcesProvider: Option[Boolean],
     buildTargetChangedProvider: Option[Boolean],
     jvmTestEnvironmentProvider: Option[Boolean],
-    jvmRunEnvironmentProvider: Option[Boolean]
+    jvmRunEnvironmentProvider: Option[Boolean],
+    canReload: Option[Boolean],
 )
 
 @JsonCodec final case class InitializeBuildResult(

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
@@ -8,6 +8,7 @@ trait Build {
   object initialize
       extends Endpoint[InitializeBuildParams, InitializeBuildResult]("build/initialize")
   object initialized extends Endpoint[InitializedBuildParams, Unit]("build/initialized")
+  object reload extends Endpoint[Reload, Unit]("build/reload")
   object exit extends Endpoint[Exit, Unit]("build/exit")
   object shutdown extends Endpoint[Shutdown, Unit]("build/shutdown")
   object showMessage extends Endpoint[ShowMessageParams, Unit]("build/showMessage")

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
@@ -8,7 +8,6 @@ trait Build {
   object initialize
       extends Endpoint[InitializeBuildParams, InitializeBuildResult]("build/initialize")
   object initialized extends Endpoint[InitializedBuildParams, Unit]("build/initialized")
-  object reload extends Endpoint[Reload, Unit]("build/reload")
   object exit extends Endpoint[Exit, Unit]("build/exit")
   object shutdown extends Endpoint[Shutdown, Unit]("build/shutdown")
   object showMessage extends Endpoint[ShowMessageParams, Unit]("build/showMessage")
@@ -64,6 +63,7 @@ trait Workspace {
   object buildTargets
       extends Endpoint[WorkspaceBuildTargetsRequest, WorkspaceBuildTargetsResult](
         "workspace/buildTargets")
+  object reload extends Endpoint[Reload, Unit]("workspace/reload")
 }
 
 object DebugSession extends DebugSession

--- a/docs/bindings/java.md
+++ b/docs/bindings/java.md
@@ -160,7 +160,6 @@ import org.eclipse.lsp4j.jsonrpc.Launcher
 class MyBuildServer extends BuildServer {
   var client: BuildClient = null // will be updated later
   def buildInitialize(params: InitializeBuildParams): CompletableFuture[InitializeBuildResult] = ???
-  def buildReload(): CompletableFuture[Object] = ???
   def buildShutdown(): CompletableFuture[Object] = ???
   def buildTargetCleanCache(params: CleanCacheParams): CompletableFuture[CleanCacheResult] = ???
   def buildTargetCompile(params: CompileParams): CompletableFuture[CompileResult] = ???
@@ -173,6 +172,7 @@ class MyBuildServer extends BuildServer {
   def onBuildExit(): Unit = ???
   def onBuildInitialized(): Unit = ???
   def workspaceBuildTargets(): CompletableFuture[WorkspaceBuildTargetsResult] = ???
+  def workspaceReload(): CompletableFuture[Object] = ???
 }
 val localServer = new MyBuildServer()
 ```

--- a/docs/bindings/java.md
+++ b/docs/bindings/java.md
@@ -160,6 +160,7 @@ import org.eclipse.lsp4j.jsonrpc.Launcher
 class MyBuildServer extends BuildServer {
   var client: BuildClient = null // will be updated later
   def buildInitialize(params: InitializeBuildParams): CompletableFuture[InitializeBuildResult] = ???
+  def buildReload(): CompletableFuture[Object] = ???
   def buildShutdown(): CompletableFuture[Object] = ???
   def buildTargetCleanCache(params: CleanCacheParams): CompletableFuture[CleanCacheResult] = ???
   def buildTargetCompile(params: CompileParams): CompletableFuture[CompileResult] = ???

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -372,7 +372,7 @@ export interface BuildServerCapabilities {
    * via method buildTarget/resources */
   resourcesProvider?: Boolean;
 
-  /** Reloading the build state through build/reload is supported */
+  /** Reloading the build state through workspace/reload is supported */
   canReload?: Boolean
 
   /** The server sends notifications to the client on build
@@ -413,24 +413,6 @@ Notification:
 ```ts
 export interface InitializedBuildParams {}
 ```
-
-### Reload request
-
-The `reload` request instructs the build server to reload the build configuration.
-This request should be supported by build tools that keep their state in memory.
-If the `reload` request returns with an error, it's expected that other requests 
-respond with the previously known "good" state.
-
-Request:
-
-- method: `build/reload`
-- params: `null`
-
-Response:
-
-- result: `null`
-- error: code and message in case an error happens during reload. For example, 
-when the build configuration is invalid
 
 #### Shutdown Build Request
 
@@ -622,6 +604,24 @@ export interface WorkspaceBuildTargetsResult {
   targets: BuildTarget[];
 }
 ```
+
+### Reload request
+
+The `reload` request is sent from the client to instruct the build server to reload 
+the build configuration. This request should be supported by build tools that keep 
+their state in memory. If the `reload` request returns with an error, it's expected 
+that other requests respond with the previously known "good" state.
+
+Request:
+
+- method: `workspace/reload`
+- params: `null`
+
+Response:
+
+- result: `null`
+- error: code and message in case an error happens during reload. For example, 
+when the build configuration is invalid.
 
 ### Build Target Changed Notification
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -372,6 +372,9 @@ export interface BuildServerCapabilities {
    * via method buildTarget/resources */
   resourcesProvider?: Boolean;
 
+  /** Reloading the build state through build/reload is supported */
+  canReload?: Boolean
+
   /** The server sends notifications to the client on build
    * target change events via buildTarget/didChange */
   buildTargetChangedProvider?: Boolean;
@@ -410,6 +413,24 @@ Notification:
 ```ts
 export interface InitializedBuildParams {}
 ```
+
+### Reload request
+
+The `reload` request instructs the build server to reload the build configuration.
+This request should be supported by build tools that keep their state in memory.
+If the `reload` request returns with an error, it's expected that other requests 
+respond with the previously known "good" state.
+
+Request:
+
+- method: `build/reload`
+- params: `null`
+
+Response:
+
+- result: `null`
+- error: code and message in case an error happens during reload. For example, 
+when the build configuration is invalid
 
 #### Shutdown Build Request
 
@@ -647,6 +668,7 @@ export namespace BuildTargetEventKind {
 
 The `BuildTargetEventKind` information can be used by clients to trigger
 reindexing or update the user interface with the new information.
+
 
 ### Build Target Sources Request
 

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
@@ -31,6 +31,7 @@ trait Bsp4jGenerators {
     dependencySourcesProvider <- BoxedGen.boolean.nullable
     resourcesProvider <- BoxedGen.boolean.nullable
     buildTargetChangedProvider <- BoxedGen.boolean.nullable
+    canReload <- BoxedGen.boolean.nullable
   } yield {
     val capabilities = new BuildServerCapabilities()
     capabilities.setCompileProvider(compileProvider)
@@ -39,6 +40,7 @@ trait Bsp4jGenerators {
     capabilities.setDependencySourcesProvider(dependencySourcesProvider)
     capabilities.setResourcesProvider(resourcesProvider)
     capabilities.setBuildTargetChangedProvider(buildTargetChangedProvider)
+    capabilities.setCanReload(canReload)
     capabilities
   }
 

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
@@ -193,9 +193,6 @@ class HappyMockServer(base: File) extends AbstractMockServer {
   override def onBuildInitialized(): Unit =
     handleBuildInitializeRequest { Right(isInitialized.success(Right(()))) }
 
-  override def buildReload(): CompletableFuture[AnyRef] =
-    CompletableFuture.completedFuture(null)
-
   override def buildShutdown(): CompletableFuture[AnyRef] = {
     handleBuildShutdownRequest {
       isShutdown.success(Right())
@@ -235,6 +232,9 @@ class HappyMockServer(base: File) extends AbstractMockServer {
       val result = new WorkspaceBuildTargetsResult(compileTargets.values.toList.asJava)
       Right(result)
     }
+
+  override def workspaceReload(): CompletableFuture[AnyRef] =
+    CompletableFuture.completedFuture(null)
 
   override def buildTargetSources(params: SourcesParams): CompletableFuture[SourcesResult] =
     handleRequest {

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
@@ -53,6 +53,7 @@ class HappyMockServer(base: File) extends AbstractMockServer {
     c.setBuildTargetChangedProvider(true)
     c.setJvmRunEnvironmentProvider(true)
     c.setJvmTestEnvironmentProvider(true)
+    c.setCanReload(true)
     c
   }
 
@@ -191,6 +192,9 @@ class HappyMockServer(base: File) extends AbstractMockServer {
 
   override def onBuildInitialized(): Unit =
     handleBuildInitializeRequest { Right(isInitialized.success(Right(()))) }
+
+  override def buildReload(): CompletableFuture[AnyRef] =
+    CompletableFuture.completedFuture(null)
 
   override def buildShutdown(): CompletableFuture[AnyRef] = {
     handleBuildShutdownRequest {
@@ -515,4 +519,5 @@ class HappyMockServer(base: File) extends AbstractMockServer {
     )
     future
   }
+
 }

--- a/tests/src/test/scala/tests/TypoSuite.scala
+++ b/tests/src/test/scala/tests/TypoSuite.scala
@@ -85,7 +85,7 @@ class TypoSuite extends FunSuite {
     override def onBuildInitialized(): Unit =
       ()
 
-    override def buildReload(): CompletableFuture[Object] =
+    override def workspaceReload(): CompletableFuture[Object] =
       CompletableFuture.completedFuture(null)
 
     override def buildShutdown(): CompletableFuture[Object] = {
@@ -198,9 +198,9 @@ class TypoSuite extends FunSuite {
     Services
       .empty(scribe.Logger.root)
       .forwardRequest(s.Build.initialize)
-      .forwardRequest(s.Build.reload)
       .forwardRequest(s.Build.shutdown)
       .forwardRequest(s.Workspace.buildTargets)
+      .forwardRequest(s.Workspace.reload)
       .forwardRequest(s.BuildTarget.sources)
       .forwardRequest(s.BuildTarget.inverseSources)
       .forwardRequest(s.BuildTarget.resources)
@@ -375,7 +375,7 @@ class TypoSuite extends FunSuite {
         test <- scala1
           .buildTargetTest(new TestParams(buildTargetUris))
           .toScala
-        _ <- scala1.buildReload().toScala
+        _ <- scala1.workspaceReload().toScala
         _ <- scala1.buildShutdown().toScala
         workspace <- scala1.workspaceBuildTargets().toScala
       } yield {


### PR DESCRIPTION
The `reload` request instructs the build server to reload the build configuration.
This request should be supported by build tools that keep their state in memory.
If the `reload` request returns with an error, it's expected that other requests
respond with the previously known "good" state.

This request is motivated by tools such as sbt, which maintain an in-memory state of the build, where reloading the build on-demand is not considered practical.

Prompted by discussion in https://github.com/sbt/sbt/issues/5783
Solves #134 

cc @adpi2