### PR TITLE
Add support for remote debugging

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/DebugSessionParamsDataKind.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/DebugSessionParamsDataKind.java
@@ -3,4 +3,5 @@ package ch.epfl.scala.bsp4j;
 public final class DebugSessionParamsDataKind {
     public static final String SCALA_MAIN_CLASS = "scala-main-class";
     public static final String SCALA_TEST_SUITES = "scala-test-suites";
+    public static final String SCALA_ATTACH_REMOTE = "scala-attach-remote";
 }

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -689,6 +689,7 @@ object TestParamsDataKind {
 object DebugSessionParamsDataKind {
   val ScalaMainClass = "scala-main-class"
   val ScalaTestSuites = "scala-test-suites"
+  val ScalaAttachRemote = "scala-attach-remote"
 }
 
 @JsonCodec final case class DebugSessionAddress(uri: String)


### PR DESCRIPTION
Extend `DebugSessionParamsDataKind` to support remote debugging.

Prerequisite of supporting remote debugging in bloop (and metals), see https://github.com/scalacenter/bloop/pull/1378