### PR TITLE
add jvm options to ScalaTestParams

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/ScalaExtension.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/ScalaExtension.xtend
@@ -26,6 +26,7 @@ class ScalaBuildTarget {
 @JsonRpcData
 class ScalaTestParams {
   List<ScalaTestClassesItem> testClasses
+  List<String> jvmOptions
 }
 
 @JsonRpcData

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestParams.java
@@ -9,6 +9,8 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 public class ScalaTestParams {
   private List<ScalaTestClassesItem> testClasses;
   
+  private List<String> jvmOptions;
+  
   @Pure
   public List<ScalaTestClassesItem> getTestClasses() {
     return this.testClasses;
@@ -18,11 +20,21 @@ public class ScalaTestParams {
     this.testClasses = testClasses;
   }
   
+  @Pure
+  public List<String> getJvmOptions() {
+    return this.jvmOptions;
+  }
+  
+  public void setJvmOptions(final List<String> jvmOptions) {
+    this.jvmOptions = jvmOptions;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("testClasses", this.testClasses);
+    b.add("jvmOptions", this.jvmOptions);
     return b.toString();
   }
   
@@ -41,12 +53,20 @@ public class ScalaTestParams {
         return false;
     } else if (!this.testClasses.equals(other.testClasses))
       return false;
+    if (this.jvmOptions == null) {
+      if (other.jvmOptions != null)
+        return false;
+    } else if (!this.jvmOptions.equals(other.jvmOptions))
+      return false;
     return true;
   }
   
   @Override
   @Pure
   public int hashCode() {
-    return 31 * 1 + ((this.testClasses== null) ? 0 : this.testClasses.hashCode());
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.testClasses== null) ? 0 : this.testClasses.hashCode());
+    return prime * result + ((this.jvmOptions== null) ? 0 : this.jvmOptions.hashCode());
   }
 }

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -577,6 +577,7 @@ object ScalaPlatform {
 
 @JsonCodec final case class ScalaTestParams(
     testClasses: Option[List[ScalaTestClassesItem]],
+    jvmOptions: Option[List[String]],
 )
 
 object TestParamsDataKind {

--- a/docs/extensions/scala.md
+++ b/docs/extensions/scala.md
@@ -55,10 +55,10 @@ export interface ScalaTestParams {
    * It is the result of `buildTarget/scalaTestClasses`. */
   testClasses?: ScalaTestClassesItem[];
 
-  /** The jvm options to run tests with. In case of 
-   * conflict (some jvm options from a higher level) this (a) and the other (b) options should be 
-   * concatenated. In case the same jvm option appears 
-   * in both (a) an (b) than the one from (a) takes precedence.
+  /** The JVM options to run tests with. In case JVM options 
+   * are also defined on the build server, they should be 
+   * concatenated with these. In case they conflict, these 
+   * should take precedence.
    */
   jvmOptions?: String[];
 }

--- a/docs/extensions/scala.md
+++ b/docs/extensions/scala.md
@@ -55,7 +55,11 @@ export interface ScalaTestParams {
    * It is the result of `buildTarget/scalaTestClasses`. */
   testClasses?: ScalaTestClassesItem[];
 
-  /** The jvm options to run tests with. */
+  /** The jvm options to run tests with. In case of 
+   * conflict (some jvm options from a higher level) this (a) and the other (b) options should be 
+   * concatenated. In case the same jvm option appears 
+   * in both (a) an (b) than the one from (a) takes precedence.
+   */
   jvmOptions?: String[];
 }
 ```

--- a/docs/extensions/scala.md
+++ b/docs/extensions/scala.md
@@ -55,7 +55,7 @@ export interface ScalaTestParams {
    * It is the result of `buildTarget/scalaTestClasses`. */
   testClasses?: ScalaTestClassesItem[];
 
-  /** The JVM options to run tests with. Replace any options 
+  /** The JVM options to run tests with. They replace any options 
    * that are defined by the build server if defined.
    */
   jvmOptions?: String[];

--- a/docs/extensions/scala.md
+++ b/docs/extensions/scala.md
@@ -54,6 +54,9 @@ export interface ScalaTestParams {
   /** The test classes to be run in this test execution.
    * It is the result of `buildTarget/scalaTestClasses`. */
   testClasses?: ScalaTestClassesItem[];
+
+  /** The jvm options to run tests with. */
+  jvmOptions?: String[];
 }
 ```
 

--- a/docs/extensions/scala.md
+++ b/docs/extensions/scala.md
@@ -55,10 +55,8 @@ export interface ScalaTestParams {
    * It is the result of `buildTarget/scalaTestClasses`. */
   testClasses?: ScalaTestClassesItem[];
 
-  /** The JVM options to run tests with. In case JVM options 
-   * are also defined on the build server, they should be 
-   * concatenated with these. In case they conflict, these 
-   * should take precedence.
+  /** The JVM options to run tests with. Shouldn't be 
+   * extended or overwritten by the build server.
    */
   jvmOptions?: String[];
 }

--- a/docs/extensions/scala.md
+++ b/docs/extensions/scala.md
@@ -55,8 +55,8 @@ export interface ScalaTestParams {
    * It is the result of `buildTarget/scalaTestClasses`. */
   testClasses?: ScalaTestClassesItem[];
 
-  /** The JVM options to run tests with. Shouldn't be 
-   * extended or overwritten by the build server.
+  /** The JVM options to run tests with. Replace any options 
+   * that are defined by the build server if defined.
    */
   jvmOptions?: String[];
 }

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
@@ -408,9 +408,11 @@ trait Bsp4jGenerators {
 
   lazy val genScalaTestParams: Gen[ScalaTestParams] = for {
     items <- genScalaTestClassesItem.list.nullable
+    jvmOptions <- arbitrary[String].list.nullable
   } yield {
     val params = new ScalaTestParams()
     params.setTestClasses(items)
+    params.setJvmOptions(jvmOptions)
     params
   }
 

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jShrinkers.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jShrinkers.scala
@@ -439,9 +439,11 @@ trait Bsp4jShrinkers extends UtilShrinkers {
   implicit def shrinkScalaTestParams: Shrink[ScalaTestParams] = Shrink { a =>
     for {
       items <- shrink(a.getTestClasses)
+      jvmOptions <- shrink(a.getJvmOptions)
     } yield {
       val params = new ScalaTestParams()
       params.setTestClasses(items)
+      params.setJvmOptions(jvmOptions)
       params
     }
   }


### PR DESCRIPTION
Reasoning behind this is described in https://github.com/build-server-protocol/build-server-protocol/issues/143
I've taken changes from https://github.com/build-server-protocol/build-server-protocol/pull/96 and made them on latest master + made jvmOptions nullable.