### PR TITLE
Improve testkit error readability

### DIFF
--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/TestClient.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/TestClient.scala
@@ -2,7 +2,6 @@ package ch.epfl.scala.bsp.testkit.client
 
 import java.io.{File, InputStream, OutputStream}
 import java.util.concurrent.{CompletableFuture, Executors}
-
 import ch.epfl.scala.bsp.testkit.client.mock.{MockCommunications, MockSession}
 import ch.epfl.scala.bsp4j._
 
@@ -12,13 +11,7 @@ import scala.collection.mutable.ListBuffer
 import scala.compat.java8.DurationConverters._
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.{Duration, DurationInt}
-import scala.concurrent.{
-  Await,
-  ExecutionContext,
-  ExecutionContextExecutor,
-  Future,
-  TimeoutException
-}
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, ExecutionException, Future, TimeoutException}
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
@@ -45,6 +38,8 @@ class TestClient(
     } catch {
       case _: TimeoutException =>
         throw new OutOfTimeException()
+      case e: ExecutionException =>
+        throw new TestFailedException(e.getCause)
       case e: Throwable =>
         throw new TestFailedException(e)
     }

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/mock/MockSession.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/mock/MockSession.scala
@@ -2,9 +2,10 @@ package ch.epfl.scala.bsp.testkit.client.mock
 
 import java.io.{InputStream, OutputStream}
 import java.util.concurrent.{ExecutorService, Executors}
-
 import ch.epfl.scala.bsp4j.{BuildServer, InitializeBuildParams}
 import org.eclipse.lsp4j.jsonrpc.Launcher
+
+import scala.util.Try
 
 case class MockSession(
     in: java.io.InputStream,
@@ -28,7 +29,7 @@ case class MockSession(
       .create()
 
     val listening = launcher.startListening
-    new Thread (() => listening.get()).start()
+    new Thread (() => Try(listening.get())).start()
 
     val server: BuildServer = launcher.getRemoteProxy
 

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/mock/MockSession.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/mock/MockSession.scala
@@ -29,7 +29,14 @@ case class MockSession(
       .create()
 
     val listening = launcher.startListening
-    new Thread (() => Try(listening.get())).start()
+    new Thread(
+      () =>
+        try {
+          listening.get()
+        } catch {
+          case _: Throwable => //Ignore all errors while listening to the launcher
+        }
+    ).start()
 
     val server: BuildServer = launcher.getRemoteProxy
 


### PR DESCRIPTION
Removed logging of cancellation expections coming cancelling the server after tests were finished

Improved readability of testkit assertion related errors, by removing the `ExecutionException` layer and only throwing the assertion error, which improves readability of errors from
```
java.util.concurrent.ExecutionException: Boxed Error
ch.epfl.scala.bsp.testkit.client.TestFailedException: java.util.concurrent.ExecutionException: Boxed Error
(...)
```

to 

```
java.lang.AssertionError: assertion failed: Cleaned cache successfully, when it should have failed
ch.epfl.scala.bsp.testkit.client.TestFailedException: java.lang.AssertionError: assertion failed: Cleaned cache successfully, when it should have failed
(...)
```   