### PR TITLE
Return empty stream on empty path

### DIFF
--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/UtilShrinkers.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/UtilShrinkers.scala
@@ -48,9 +48,12 @@ trait UtilShrinkers {
   }
 
   implicit def shrinkPath: Shrink[Path] = Shrink { path =>
-    shrinkRight.shrink(path.iterator.asScala.toIterable).map { parts =>
-      Paths.get(parts.mkString("/"))
-    }
+    val partIt = path.iterator()
+    if (partIt.hasNext)
+      shrinkRight.shrink(path.iterator.asScala.toIterable).map { parts =>
+        Paths.get(parts.mkString("/"))
+      }
+    else Stream.empty
   }
 
   def shrinkFileUri: Shrink[URI] = Shrink { uri: URI =>


### PR DESCRIPTION
Whenever generating paths with the testkit for clients, the shrinker for paths may get an empty string value. Whenever this was the case, the shrinker returned another empty string, leading to a cycle. This prevents that.