### PR TITLE
Path shrinker returning empty on empty string

### DIFF
--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/UtilShrinkers.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/UtilShrinkers.scala
@@ -49,7 +49,7 @@ trait UtilShrinkers {
 
   implicit def shrinkPath: Shrink[Path] = Shrink { path =>
     val partIt = path.iterator()
-    if (partIt.hasNext)
+    if (partIt.hasNext && !path.startsWith(""))
       shrinkRight.shrink(path.iterator.asScala.toIterable).map { parts =>
         Paths.get(parts.mkString("/"))
       }


### PR DESCRIPTION
Whenever a path is an empty string, the iterator returns has having a next. This is, apparently, undefined behavior. Here's an example of this:
![image](https://user-images.githubusercontent.com/33755974/106172800-212edd80-618b-11eb-9f36-22302e4a574c.png)
