### PR TITLE
Fix scalac and javac options testkit methods

### DIFF
--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/TestClient.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/TestClient.scala
@@ -692,9 +692,10 @@ class TestClient(
             expectedItem =>
               testExpectedClasspath(expectedItem.getClasspath, item.getClasspath) &&
                 item.getClassDirectory.contains(expectedItem.getClassDirectory) &&
-                item.getTarget == expectedItem.getTarget
-          ) &&
-          item.getOptions == item.getOptions
+                item.getTarget == expectedItem.getTarget &&
+                item.getOptions == expectedItem.getOptions
+
+          )
         }
         assert(
           itemsTest,
@@ -724,9 +725,9 @@ class TestClient(
             expectedItem =>
               testExpectedClasspath(expectedItem.getClasspath, item.getClasspath) &&
                 item.getClassDirectory.contains(expectedItem.getClassDirectory) &&
-                item.getTarget == expectedItem.getTarget
-          ) &&
-          item.getOptions == item.getOptions
+                item.getTarget == expectedItem.getTarget &&
+                item.getOptions == expectedItem.getOptions
+          )
         }
         assert(
           itemsTest,


### PR DESCRIPTION
Found a bug on the options comparison of the scalac and javac options methods regarding the comparison of the options themselves.