### PR TITLE
Add debug provider to build server capabilities

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -32,11 +32,13 @@ class BuildTargetCapabilities {
   @NonNull Boolean canCompile
   @NonNull Boolean canTest
   @NonNull Boolean canRun
+  @NonNull Boolean canDebug
 
-  new (Boolean canCompile, Boolean canTest, Boolean canRun) {
+  new (Boolean canCompile, Boolean canTest, Boolean canRun, Boolean canDebug) {
     this.canCompile = canCompile
     this.canTest = canTest
     this.canRun = canRun
+    this.canDebug = canDebug
   }
 }
 
@@ -81,7 +83,6 @@ class InitializeBuildParams {
   }
 }
 
-
 @JsonRpcData
 class BuildClientCapabilities {
   @NonNull List<String> languageIds
@@ -89,7 +90,6 @@ class BuildClientCapabilities {
     this.languageIds = languageIds
   }
 }
-
 
 @JsonRpcData
 class CompileProvider {
@@ -116,10 +116,19 @@ class RunProvider {
 }
 
 @JsonRpcData
+class DebugProvider {
+  @NonNull List<String> languageIds
+  new(@NonNull List<String> languageIds) {
+    this.languageIds = languageIds
+  }
+}
+
+@JsonRpcData
 class BuildServerCapabilities {
   CompileProvider compileProvider
   TestProvider testProvider
   RunProvider runProvider
+  DebugProvider debugProvider
   Boolean inverseSourcesProvider
   Boolean dependencySourcesProvider
   Boolean resourcesProvider

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -32,7 +32,7 @@ class BuildTargetCapabilities {
   @NonNull Boolean canCompile
   @NonNull Boolean canTest
   @NonNull Boolean canRun
-  @NonNull Boolean canDebug
+  Boolean canDebug = false
 
   new (Boolean canCompile, Boolean canTest, Boolean canRun, Boolean canDebug) {
     this.canCompile = canCompile

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -32,9 +32,23 @@ class BuildTargetCapabilities {
   @NonNull Boolean canCompile
   @NonNull Boolean canTest
   @NonNull Boolean canRun
-  Boolean canDebug = false
+  @NonNull Boolean canDebug
 
-  new (Boolean canCompile, Boolean canTest, Boolean canRun, Boolean canDebug) {
+  new () {
+    this.canCompile = Boolean.FALSE
+    this.canTest = Boolean.FALSE
+    this.canRun = Boolean.FALSE
+    this.canDebug = Boolean.FALSE
+  }
+
+  new (@NonNull Boolean canCompile, @NonNull Boolean canTest, @NonNull Boolean canRun) {
+    this.canCompile = canCompile
+    this.canTest = canTest
+    this.canRun = canRun
+    this.canDebug = Boolean.FALSE
+  }
+
+  new (@NonNull Boolean canCompile, @NonNull Boolean canTest, @NonNull Boolean canRun, @NonNull Boolean canDebug) {
     this.canCompile = canCompile
     this.canTest = canTest
     this.canRun = canRun

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildServerCapabilities.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildServerCapabilities.java
@@ -1,6 +1,7 @@
 package ch.epfl.scala.bsp4j;
 
 import ch.epfl.scala.bsp4j.CompileProvider;
+import ch.epfl.scala.bsp4j.DebugProvider;
 import ch.epfl.scala.bsp4j.RunProvider;
 import ch.epfl.scala.bsp4j.TestProvider;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -13,6 +14,8 @@ public class BuildServerCapabilities {
   private TestProvider testProvider;
   
   private RunProvider runProvider;
+  
+  private DebugProvider debugProvider;
   
   private Boolean inverseSourcesProvider;
   
@@ -53,6 +56,15 @@ public class BuildServerCapabilities {
   
   public void setRunProvider(final RunProvider runProvider) {
     this.runProvider = runProvider;
+  }
+  
+  @Pure
+  public DebugProvider getDebugProvider() {
+    return this.debugProvider;
+  }
+  
+  public void setDebugProvider(final DebugProvider debugProvider) {
+    this.debugProvider = debugProvider;
   }
   
   @Pure
@@ -125,6 +137,7 @@ public class BuildServerCapabilities {
     b.add("compileProvider", this.compileProvider);
     b.add("testProvider", this.testProvider);
     b.add("runProvider", this.runProvider);
+    b.add("debugProvider", this.debugProvider);
     b.add("inverseSourcesProvider", this.inverseSourcesProvider);
     b.add("dependencySourcesProvider", this.dependencySourcesProvider);
     b.add("resourcesProvider", this.resourcesProvider);
@@ -159,6 +172,11 @@ public class BuildServerCapabilities {
       if (other.runProvider != null)
         return false;
     } else if (!this.runProvider.equals(other.runProvider))
+      return false;
+    if (this.debugProvider == null) {
+      if (other.debugProvider != null)
+        return false;
+    } else if (!this.debugProvider.equals(other.debugProvider))
       return false;
     if (this.inverseSourcesProvider == null) {
       if (other.inverseSourcesProvider != null)
@@ -206,6 +224,7 @@ public class BuildServerCapabilities {
     result = prime * result + ((this.compileProvider== null) ? 0 : this.compileProvider.hashCode());
     result = prime * result + ((this.testProvider== null) ? 0 : this.testProvider.hashCode());
     result = prime * result + ((this.runProvider== null) ? 0 : this.runProvider.hashCode());
+    result = prime * result + ((this.debugProvider== null) ? 0 : this.debugProvider.hashCode());
     result = prime * result + ((this.inverseSourcesProvider== null) ? 0 : this.inverseSourcesProvider.hashCode());
     result = prime * result + ((this.dependencySourcesProvider== null) ? 0 : this.dependencySourcesProvider.hashCode());
     result = prime * result + ((this.resourcesProvider== null) ? 0 : this.resourcesProvider.hashCode());

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetCapabilities.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetCapabilities.java
@@ -16,9 +16,24 @@ public class BuildTargetCapabilities {
   @NonNull
   private Boolean canRun;
   
-  private Boolean canDebug = Boolean.valueOf(false);
+  @NonNull
+  private Boolean canDebug;
   
-  public BuildTargetCapabilities(final Boolean canCompile, final Boolean canTest, final Boolean canRun, final Boolean canDebug) {
+  public BuildTargetCapabilities() {
+    this.canCompile = Boolean.FALSE;
+    this.canTest = Boolean.FALSE;
+    this.canRun = Boolean.FALSE;
+    this.canDebug = Boolean.FALSE;
+  }
+  
+  public BuildTargetCapabilities(@NonNull final Boolean canCompile, @NonNull final Boolean canTest, @NonNull final Boolean canRun) {
+    this.canCompile = canCompile;
+    this.canTest = canTest;
+    this.canRun = canRun;
+    this.canDebug = Boolean.FALSE;
+  }
+  
+  public BuildTargetCapabilities(@NonNull final Boolean canCompile, @NonNull final Boolean canTest, @NonNull final Boolean canRun, @NonNull final Boolean canDebug) {
     this.canCompile = canCompile;
     this.canTest = canTest;
     this.canRun = canRun;
@@ -56,12 +71,13 @@ public class BuildTargetCapabilities {
   }
   
   @Pure
+  @NonNull
   public Boolean getCanDebug() {
     return this.canDebug;
   }
   
-  public void setCanDebug(final Boolean canDebug) {
-    this.canDebug = canDebug;
+  public void setCanDebug(@NonNull final Boolean canDebug) {
+    this.canDebug = Preconditions.checkNotNull(canDebug, "canDebug");
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetCapabilities.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetCapabilities.java
@@ -16,8 +16,7 @@ public class BuildTargetCapabilities {
   @NonNull
   private Boolean canRun;
   
-  @NonNull
-  private Boolean canDebug;
+  private Boolean canDebug = Boolean.valueOf(false);
   
   public BuildTargetCapabilities(final Boolean canCompile, final Boolean canTest, final Boolean canRun, final Boolean canDebug) {
     this.canCompile = canCompile;
@@ -57,13 +56,12 @@ public class BuildTargetCapabilities {
   }
   
   @Pure
-  @NonNull
   public Boolean getCanDebug() {
     return this.canDebug;
   }
   
-  public void setCanDebug(@NonNull final Boolean canDebug) {
-    this.canDebug = Preconditions.checkNotNull(canDebug, "canDebug");
+  public void setCanDebug(final Boolean canDebug) {
+    this.canDebug = canDebug;
   }
   
   @Override

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetCapabilities.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetCapabilities.java
@@ -16,10 +16,14 @@ public class BuildTargetCapabilities {
   @NonNull
   private Boolean canRun;
   
-  public BuildTargetCapabilities(final Boolean canCompile, final Boolean canTest, final Boolean canRun) {
+  @NonNull
+  private Boolean canDebug;
+  
+  public BuildTargetCapabilities(final Boolean canCompile, final Boolean canTest, final Boolean canRun, final Boolean canDebug) {
     this.canCompile = canCompile;
     this.canTest = canTest;
     this.canRun = canRun;
+    this.canDebug = canDebug;
   }
   
   @Pure
@@ -52,6 +56,16 @@ public class BuildTargetCapabilities {
     this.canRun = Preconditions.checkNotNull(canRun, "canRun");
   }
   
+  @Pure
+  @NonNull
+  public Boolean getCanDebug() {
+    return this.canDebug;
+  }
+  
+  public void setCanDebug(@NonNull final Boolean canDebug) {
+    this.canDebug = Preconditions.checkNotNull(canDebug, "canDebug");
+  }
+  
   @Override
   @Pure
   public String toString() {
@@ -59,6 +73,7 @@ public class BuildTargetCapabilities {
     b.add("canCompile", this.canCompile);
     b.add("canTest", this.canTest);
     b.add("canRun", this.canRun);
+    b.add("canDebug", this.canDebug);
     return b.toString();
   }
   
@@ -87,6 +102,11 @@ public class BuildTargetCapabilities {
         return false;
     } else if (!this.canRun.equals(other.canRun))
       return false;
+    if (this.canDebug == null) {
+      if (other.canDebug != null)
+        return false;
+    } else if (!this.canDebug.equals(other.canDebug))
+      return false;
     return true;
   }
   
@@ -97,6 +117,7 @@ public class BuildTargetCapabilities {
     int result = 1;
     result = prime * result + ((this.canCompile== null) ? 0 : this.canCompile.hashCode());
     result = prime * result + ((this.canTest== null) ? 0 : this.canTest.hashCode());
-    return prime * result + ((this.canRun== null) ? 0 : this.canRun.hashCode());
+    result = prime * result + ((this.canRun== null) ? 0 : this.canRun.hashCode());
+    return prime * result + ((this.canDebug== null) ? 0 : this.canDebug.hashCode());
   }
 }

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DebugProvider.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DebugProvider.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class DebugProvider {
+  @NonNull
+  private List<String> languageIds;
+  
+  public DebugProvider(@NonNull final List<String> languageIds) {
+    this.languageIds = languageIds;
+  }
+  
+  @Pure
+  @NonNull
+  public List<String> getLanguageIds() {
+    return this.languageIds;
+  }
+  
+  public void setLanguageIds(@NonNull final List<String> languageIds) {
+    this.languageIds = Preconditions.checkNotNull(languageIds, "languageIds");
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("languageIds", this.languageIds);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DebugProvider other = (DebugProvider) obj;
+    if (this.languageIds == null) {
+      if (other.languageIds != null)
+        return false;
+    } else if (!this.languageIds.equals(other.languageIds))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.languageIds== null) ? 0 : this.languageIds.hashCode());
+  }
+}

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -45,7 +45,7 @@ object Uri {
     canCompile: Boolean,
     canTest: Boolean,
     canRun: Boolean,
-    canDebug: Boolean,
+    canDebug: Boolean = false, // backward compatible default
 )
 
 object BuildTargetTag {

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -5,6 +5,8 @@ import java.net.{URI, URISyntaxException}
 import io.circe.Decoder.Result
 import io.circe._
 import io.circe.derivation.JsonCodec
+import io.circe.generic.extras._
+import io.circe.generic.extras.semiauto.{deriveDecoder, deriveEncoder}
 
 final case class Uri private[Uri] (val value: String) {
   def toPath: java.nio.file.Path =
@@ -41,7 +43,13 @@ object Uri {
     uri: Uri
 )
 
-@JsonCodec final case class BuildTargetCapabilities(
+object BuildTargetCapabilities {
+  implicit val config: Configuration = Configuration.default.withDefaults
+  implicit val jsonDecoder: Decoder[BuildTargetCapabilities] = deriveDecoder
+  implicit val jsonEncoder: Encoder[BuildTargetCapabilities] = deriveEncoder
+}
+
+final case class BuildTargetCapabilities(
     canCompile: Boolean,
     canTest: Boolean,
     canRun: Boolean,

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -45,6 +45,7 @@ object Uri {
     canCompile: Boolean,
     canTest: Boolean,
     canRun: Boolean,
+    canDebug: Boolean,
 )
 
 object BuildTargetTag {
@@ -109,10 +110,15 @@ object BuildTargetDataKind {
     languageIds: List[String]
 )
 
+@JsonCodec final case class DebugProvider(
+  languageIds: List[String]
+)
+
 @JsonCodec final case class BuildServerCapabilities(
     compileProvider: Option[CompileProvider],
     testProvider: Option[TestProvider],
     runProvider: Option[RunProvider],
+    debugProvider: Option[DebugProvider],
     inverseSourcesProvider: Option[Boolean],
     dependencySourcesProvider: Option[Boolean],
     resourcesProvider: Option[Boolean],

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ lazy val bsp4s = project
     libraryDependencies ++= List(
       "io.circe" %% "circe-core" % "0.9.0",
       "io.circe" %% "circe-derivation" % "0.9.0-M4",
+      "io.circe" %% "circe-generic-extras" % "0.9.0",
       "org.scalameta" %% "lsp4s" % "0.2.0"
     )
   )

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -212,6 +212,8 @@ export interface BuildTargetCapabilities {
   canTest: Boolean;
   /** This target can be run by the BSP server. */
   canRun: Boolean;
+  /** This target can be debugged by the BSP server. */
+  canDebug: Boolean;
 }
 ```
 
@@ -369,6 +371,9 @@ export interface BuildServerCapabilities {
   /** The languages the server supports run via method buildTarget/run */
   runProvider?: RunProvider;
 
+  /** The languages the server supports debugging via method debugSession/start */
+  debugProvider?: DebugProvider;
+
   /** The server can provide a list of targets that contain a
    * single text document via the method buildTarget/inverseSources */
   inverseSourcesProvider?: Boolean;
@@ -394,6 +399,10 @@ export interface CompileProvider {
 }
 
 export interface RunProvider {
+  languageIds: String[];
+}
+
+export interface DebugProvider {
   languageIds: String[];
 }
 
@@ -1316,6 +1325,42 @@ response.
 
 The client will get a `originId` field in `RunResult` if the `originId` field in
 the `RunParams` is defined.
+
+### Debug Request
+
+The debug request is sent from the client to the server to debug build target(s). The
+server launches a [Microsoft DAP for Java](https://github.com/microsoft/vscode-java-debug) instance
+and returns a connection URI for the client to interact with.
+
+- method: `debugSession/start`
+- params: `DebugSessionParams`
+
+```ts
+export interface DebugSessionParams {
+  /** A sequence of build targets affected by the debugging action. */
+  targets: List[BuildTargetIdentifier],
+
+  /** The kind of data to expect in the `data` field. */
+  dataKind: String;
+
+  /** Language-specific metadata for this execution.
+   * See ScalaMainClass as an example. */
+  data: any;
+}
+```
+
+Response:
+
+- result: `DebugSessionAddress`, defined as follows
+- error: JSON-RPC code and message set in case an exception happens during the
+  request.
+
+```ts
+export interface DebugSessionAddress {
+  /** The Debug Adapter Protocol server's connection uri */
+  uri: Uri;
+}
+```
 
 ### Clean Cache Request
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1329,7 +1329,7 @@ the `RunParams` is defined.
 ### Debug Request
 
 The debug request is sent from the client to the server to debug build target(s). The
-server launches a [Microsoft DAP for Java](https://github.com/microsoft/vscode-java-debug) instance
+server launches a [Microsoft DAP](https://microsoft.github.io/debug-adapter-protocol/) server
 and returns a connection URI for the client to interact with.
 
 - method: `debugSession/start`

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
@@ -27,6 +27,7 @@ trait Bsp4jGenerators {
   val genBuildServerCapabilities: Gen[BuildServerCapabilities] = for {
     compileProvider <- genCompileProvider.nullable
     testProvider <- genTestProvider.nullable
+    debugProvider <- genDebugProvider.nullable
     inverseSourcesProvider <- BoxedGen.boolean.nullable
     dependencySourcesProvider <- BoxedGen.boolean.nullable
     resourcesProvider <- BoxedGen.boolean.nullable
@@ -36,6 +37,7 @@ trait Bsp4jGenerators {
     val capabilities = new BuildServerCapabilities()
     capabilities.setCompileProvider(compileProvider)
     capabilities.setTestProvider(testProvider)
+    capabilities.setDebugProvider(debugProvider)
     capabilities.setInverseSourcesProvider(inverseSourcesProvider)
     capabilities.setDependencySourcesProvider(dependencySourcesProvider)
     capabilities.setResourcesProvider(resourcesProvider)
@@ -79,7 +81,8 @@ trait Bsp4jGenerators {
     canCompile <- arbitrary[Boolean]
     canTest <- arbitrary[Boolean]
     canRun <- arbitrary[Boolean]
-  } yield new BuildTargetCapabilities(canCompile, canTest, canRun)
+    canDebug <- arbitrary[Boolean]
+  } yield new BuildTargetCapabilities(canCompile, canTest, canRun, canDebug)
 
   lazy val genBuildTargetEvent: Gen[BuildTargetEvent] = for {
     target <- genBuildTargetIdentifier
@@ -556,6 +559,10 @@ trait Bsp4jGenerators {
   lazy val genTestProvider: Gen[TestProvider] = for {
     languageIds <- genLanguageId.list
   } yield new TestProvider(languageIds)
+
+  lazy val genDebugProvider: Gen[DebugProvider] = for {
+    languageIds <- genLanguageId.list
+  } yield new DebugProvider(languageIds)
 
   lazy val genTestReport: Gen[TestReport] = for {
     target <- genBuildTargetIdentifier

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jShrinkers.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jShrinkers.scala
@@ -35,6 +35,7 @@ trait Bsp4jShrinkers extends UtilShrinkers {
     for {
       compileProvider <- shrink(capabilities.getCompileProvider)
       testProvider <- shrink(capabilities.getTestProvider)
+      debugProvider <- shrink(capabilities.getDebugProvider)
       inverseSourcesProvider <- shrink(capabilities.getInverseSourcesProvider)
       dependencySourcesProvider <- shrink(capabilities.getDependencySourcesProvider)
       resourcesProvider <- shrink(capabilities.getResourcesProvider)
@@ -43,6 +44,7 @@ trait Bsp4jShrinkers extends UtilShrinkers {
       val capabilities = new BuildServerCapabilities()
       capabilities.setCompileProvider(compileProvider)
       capabilities.setTestProvider(testProvider)
+      capabilities.setDebugProvider(debugProvider)
       capabilities.setInverseSourcesProvider(inverseSourcesProvider)
       capabilities.setDependencySourcesProvider(dependencySourcesProvider)
       capabilities.setResourcesProvider(resourcesProvider)
@@ -79,7 +81,8 @@ trait Bsp4jShrinkers extends UtilShrinkers {
       canCompile <- shrink(capabilities.getCanCompile)
       canTest <- shrink(capabilities.getCanTest)
       canRun <- shrink(capabilities.getCanRun)
-    } yield new BuildTargetCapabilities(canCompile, canTest, canRun)
+      canDebug <- shrink(capabilities.getCanDebug)
+    } yield new BuildTargetCapabilities(canCompile, canTest, canRun, canDebug)
   }
 
   implicit def shrinkBuildTargetEvent: Shrink[BuildTargetEvent] = Shrink { event =>

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
@@ -47,6 +47,7 @@ class HappyMockServer(base: File) extends AbstractMockServer {
     c.setCompileProvider(new CompileProvider(supportedLanguages))
     c.setTestProvider(new TestProvider(supportedLanguages))
     c.setRunProvider(new RunProvider(supportedLanguages))
+    c.setDebugProvider(new DebugProvider(supportedLanguages))
     c.setInverseSourcesProvider(true)
     c.setDependencySourcesProvider(true)
     c.setResourcesProvider(true)
@@ -68,14 +69,14 @@ class HappyMockServer(base: File) extends AbstractMockServer {
     List(BuildTargetTag.LIBRARY).asJava,
     languageIds,
     List.empty.asJava,
-    new BuildTargetCapabilities(true, false, false)
+    new BuildTargetCapabilities(true, false, false, false)
   )
   val target2 = new BuildTarget(
     targetId2,
     List(BuildTargetTag.TEST).asJava,
     languageIds,
     List(targetId1).asJava,
-    new BuildTargetCapabilities(true, true, false)
+    new BuildTargetCapabilities(true, true, false, false)
   )
 
   val target3 = new BuildTarget(
@@ -83,7 +84,7 @@ class HappyMockServer(base: File) extends AbstractMockServer {
     List(BuildTargetTag.APPLICATION).asJava,
     languageIds,
     List(targetId1).asJava,
-    new BuildTargetCapabilities(true, false, true)
+    new BuildTargetCapabilities(true, false, true, false)
   )
 
   val compileTargets: Map[BuildTargetIdentifier, BuildTarget] = Map(

--- a/tests/src/test/scala/tests/MockClientSuite.scala
+++ b/tests/src/test/scala/tests/MockClientSuite.scala
@@ -40,14 +40,14 @@ class MockClientSuite extends FunSuite {
     List(BuildTargetTag.TEST).asJava,
     Collections.emptyList(),
     Collections.emptyList(),
-    new BuildTargetCapabilities(true, true, false)
+    new BuildTargetCapabilities(true, true, false, false)
   )
   val target3 = new BuildTarget(
     targetId3,
     List(BuildTargetTag.APPLICATION).asJava,
     Collections.emptyList(),
     Collections.emptyList(),
-    new BuildTargetCapabilities(true, false, true)
+    new BuildTargetCapabilities(true, false, true, false)
   )
 
   private val client = TestClient(

--- a/tests/src/test/scala/tests/SerializationSuite.scala
+++ b/tests/src/test/scala/tests/SerializationSuite.scala
@@ -75,4 +75,25 @@ class SerializationSuite extends FunSuite {
 
     assert(bsp4sValueDecoded == bsp4sValue)
   }
+
+  test("BuildTargetCapabilities - backward compatible canDebug") {
+    val legacyJson =
+      """
+        |{
+        |  "canCompile": true,
+        |  "canTest": true,
+        |  "canRun": true
+        |}""".stripMargin
+
+    val bsp4jValue = gson.fromJson(legacyJson, classOf[bsp4j.BuildTargetCapabilities])
+    val bsp4sValue = decode[bsp4s.BuildTargetCapabilities](legacyJson).right.get
+
+    assert(bsp4jValue.getCanCompile == bsp4sValue.canCompile)
+    assert(bsp4jValue.getCanTest == bsp4sValue.canTest)
+    assert(bsp4jValue.getCanRun == bsp4sValue.canRun)
+    assert(bsp4jValue.getCanDebug == bsp4sValue.canDebug)
+
+    assert(bsp4jValue.getCanDebug == false)
+    assert(bsp4sValue.canDebug == false)
+  }
 }

--- a/tests/src/test/scala/tests/TypoSuite.scala
+++ b/tests/src/test/scala/tests/TypoSuite.scala
@@ -74,6 +74,7 @@ class TypoSuite extends FunSuite {
         capabilities.setCompileProvider(new CompileProvider(Collections.singletonList("scala")))
         capabilities.setTestProvider(new TestProvider(Collections.singletonList("scala")))
         capabilities.setRunProvider(new RunProvider(Collections.singletonList("scala")))
+        capabilities.setDebugProvider(new DebugProvider(Collections.singletonList("scala")))
         capabilities.setInverseSourcesProvider(true)
         capabilities.setDependencySourcesProvider(true)
         capabilities.setResourcesProvider(true)
@@ -95,7 +96,7 @@ class TypoSuite extends FunSuite {
       ()
     override def workspaceBuildTargets(): CompletableFuture[WorkspaceBuildTargetsResult] = {
       CompletableFuture.completedFuture {
-        val capabilities = new BuildTargetCapabilities(true, true, true)
+        val capabilities = new BuildTargetCapabilities(true, true, true, true)
         val target = new BuildTarget(
           buildTargetUri,
           Collections.singletonList("tag"),


### PR DESCRIPTION
This attempts to address https://github.com/build-server-protocol/build-server-protocol/issues/145

Specifically, looking to improve how metals can support debug support: https://github.com/adpi2/metals/pull/1/files#diff-2249f2a7f1d0baedcc556404e0eb12adcd38f5fdb4d0d640d662643bc3de5b1fR514

TODO:
- [x] Add an explicit json deserialization test for `BuildTargetCapabilities` to verify backward compatability