### PR TITLE
Add `buildTarget/dependencyModules` BSP method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+project/metals.sbt
+project/project
 
 # Scala-IDE specific
 .scala_dependencies
@@ -27,3 +29,7 @@ node_modules
 out/
 
 *._trace
+
+.bloop
+.metals/
+.vscode

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
@@ -49,6 +49,9 @@ public interface BuildServer {
     @JsonRequest("buildTarget/cleanCache")
     CompletableFuture<CleanCacheResult> buildTargetCleanCache(CleanCacheParams params);
 
+    @JsonRequest("buildTarget/dependencyModules")
+    CompletableFuture<DependencyModulesResult> buildTargetDependencyModules(DependencyModulesParams params);
+
     default void onConnectWithClient(BuildClient server) {
 
     }

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/MavenExtension.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/MavenExtension.xtend
@@ -1,0 +1,35 @@
+package ch.epfl.scala.bsp4j
+
+import java.util.List
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull
+import org.eclipse.lsp4j.generator.JsonRpcData
+
+@JsonRpcData
+class MavenDependencyModule {
+  @NonNull String organization
+  @NonNull String name
+  @NonNull String version
+  @NonNull List<MavenDependencyModuleArtifact> artifacts
+  String scope
+  new(
+    @NonNull String organization,
+    @NonNull String name,
+    @NonNull String version,
+    @NonNull List<MavenDependencyModuleArtifact> artifacts
+  ) {
+    this.organization = organization
+    this.name = name
+    this.version = version
+    this.artifacts = artifacts
+  }
+}
+
+@JsonRpcData
+class MavenDependencyModuleArtifact {
+  @NonNull String uri
+  String classifier
+
+  new (@NonNull String uri) {
+    this.uri = uri
+  }
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -145,6 +145,7 @@ class BuildServerCapabilities {
   DebugProvider debugProvider
   Boolean inverseSourcesProvider
   Boolean dependencySourcesProvider
+  Boolean dependencyModulesProvider
   Boolean resourcesProvider
   Boolean buildTargetChangedProvider
   Boolean jvmRunEnvironmentProvider
@@ -640,4 +641,45 @@ class DebugSessionAddress {
     new(@NonNull String uri){
         this.uri = uri;
     }
+}
+
+@JsonRpcData
+class DependencyModulesParams {
+  @NonNull List<BuildTargetIdentifier> targets
+  new(@NonNull List<BuildTargetIdentifier> targets) {
+    this.targets = targets
+  }
+}
+
+@JsonRpcData
+class DependencyModulesResult {
+  @NonNull List<DependencyModulesItem> items
+
+  new(@NonNull List<DependencyModulesItem> items) {
+    this.items = items
+  }
+}
+
+@JsonRpcData
+class DependencyModulesItem {
+  @NonNull BuildTargetIdentifier target
+  @NonNull List<DependencyModule> modules
+
+  new (@NonNull BuildTargetIdentifier target, @NonNull List<DependencyModule> modules) {
+    this.target = target
+    this.modules = modules
+  }
+}
+
+@JsonRpcData
+class DependencyModule {
+  @NonNull String name
+  @NonNull String version
+  String dataKind
+  @JsonAdapter(JsonElementTypeAdapter.Factory) Object data
+
+  new (@NonNull String name, @NonNull String version) {
+    this.name = name
+    this.version = version
+  }
 }

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildServerCapabilities.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildServerCapabilities.java
@@ -21,6 +21,8 @@ public class BuildServerCapabilities {
   
   private Boolean dependencySourcesProvider;
   
+  private Boolean dependencyModulesProvider;
+  
   private Boolean resourcesProvider;
   
   private Boolean buildTargetChangedProvider;
@@ -86,6 +88,15 @@ public class BuildServerCapabilities {
   }
   
   @Pure
+  public Boolean getDependencyModulesProvider() {
+    return this.dependencyModulesProvider;
+  }
+  
+  public void setDependencyModulesProvider(final Boolean dependencyModulesProvider) {
+    this.dependencyModulesProvider = dependencyModulesProvider;
+  }
+  
+  @Pure
   public Boolean getResourcesProvider() {
     return this.resourcesProvider;
   }
@@ -140,6 +151,7 @@ public class BuildServerCapabilities {
     b.add("debugProvider", this.debugProvider);
     b.add("inverseSourcesProvider", this.inverseSourcesProvider);
     b.add("dependencySourcesProvider", this.dependencySourcesProvider);
+    b.add("dependencyModulesProvider", this.dependencyModulesProvider);
     b.add("resourcesProvider", this.resourcesProvider);
     b.add("buildTargetChangedProvider", this.buildTargetChangedProvider);
     b.add("jvmRunEnvironmentProvider", this.jvmRunEnvironmentProvider);
@@ -188,6 +200,11 @@ public class BuildServerCapabilities {
         return false;
     } else if (!this.dependencySourcesProvider.equals(other.dependencySourcesProvider))
       return false;
+    if (this.dependencyModulesProvider == null) {
+      if (other.dependencyModulesProvider != null)
+        return false;
+    } else if (!this.dependencyModulesProvider.equals(other.dependencyModulesProvider))
+      return false;
     if (this.resourcesProvider == null) {
       if (other.resourcesProvider != null)
         return false;
@@ -227,6 +244,7 @@ public class BuildServerCapabilities {
     result = prime * result + ((this.debugProvider== null) ? 0 : this.debugProvider.hashCode());
     result = prime * result + ((this.inverseSourcesProvider== null) ? 0 : this.inverseSourcesProvider.hashCode());
     result = prime * result + ((this.dependencySourcesProvider== null) ? 0 : this.dependencySourcesProvider.hashCode());
+    result = prime * result + ((this.dependencyModulesProvider== null) ? 0 : this.dependencyModulesProvider.hashCode());
     result = prime * result + ((this.resourcesProvider== null) ? 0 : this.resourcesProvider.hashCode());
     result = prime * result + ((this.buildTargetChangedProvider== null) ? 0 : this.buildTargetChangedProvider.hashCode());
     result = prime * result + ((this.jvmRunEnvironmentProvider== null) ? 0 : this.jvmRunEnvironmentProvider.hashCode());

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencyModule.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencyModule.java
@@ -1,0 +1,120 @@
+package ch.epfl.scala.bsp4j;
+
+import com.google.gson.annotations.JsonAdapter;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class DependencyModule {
+  @NonNull
+  private String name;
+  
+  @NonNull
+  private String version;
+  
+  private String dataKind;
+  
+  @JsonAdapter(JsonElementTypeAdapter.Factory.class)
+  private Object data;
+  
+  public DependencyModule(@NonNull final String name, @NonNull final String version) {
+    this.name = name;
+    this.version = version;
+  }
+  
+  @Pure
+  @NonNull
+  public String getName() {
+    return this.name;
+  }
+  
+  public void setName(@NonNull final String name) {
+    this.name = Preconditions.checkNotNull(name, "name");
+  }
+  
+  @Pure
+  @NonNull
+  public String getVersion() {
+    return this.version;
+  }
+  
+  public void setVersion(@NonNull final String version) {
+    this.version = Preconditions.checkNotNull(version, "version");
+  }
+  
+  @Pure
+  public String getDataKind() {
+    return this.dataKind;
+  }
+  
+  public void setDataKind(final String dataKind) {
+    this.dataKind = dataKind;
+  }
+  
+  @Pure
+  public Object getData() {
+    return this.data;
+  }
+  
+  public void setData(final Object data) {
+    this.data = data;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("name", this.name);
+    b.add("version", this.version);
+    b.add("dataKind", this.dataKind);
+    b.add("data", this.data);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DependencyModule other = (DependencyModule) obj;
+    if (this.name == null) {
+      if (other.name != null)
+        return false;
+    } else if (!this.name.equals(other.name))
+      return false;
+    if (this.version == null) {
+      if (other.version != null)
+        return false;
+    } else if (!this.version.equals(other.version))
+      return false;
+    if (this.dataKind == null) {
+      if (other.dataKind != null)
+        return false;
+    } else if (!this.dataKind.equals(other.dataKind))
+      return false;
+    if (this.data == null) {
+      if (other.data != null)
+        return false;
+    } else if (!this.data.equals(other.data))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.name== null) ? 0 : this.name.hashCode());
+    result = prime * result + ((this.version== null) ? 0 : this.version.hashCode());
+    result = prime * result + ((this.dataKind== null) ? 0 : this.dataKind.hashCode());
+    return prime * result + ((this.data== null) ? 0 : this.data.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencyModulesItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencyModulesItem.java
@@ -1,0 +1,84 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import ch.epfl.scala.bsp4j.DependencyModule;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class DependencyModulesItem {
+  @NonNull
+  private BuildTargetIdentifier target;
+  
+  @NonNull
+  private List<DependencyModule> modules;
+  
+  public DependencyModulesItem(@NonNull final BuildTargetIdentifier target, @NonNull final List<DependencyModule> modules) {
+    this.target = target;
+    this.modules = modules;
+  }
+  
+  @Pure
+  @NonNull
+  public BuildTargetIdentifier getTarget() {
+    return this.target;
+  }
+  
+  public void setTarget(@NonNull final BuildTargetIdentifier target) {
+    this.target = Preconditions.checkNotNull(target, "target");
+  }
+  
+  @Pure
+  @NonNull
+  public List<DependencyModule> getModules() {
+    return this.modules;
+  }
+  
+  public void setModules(@NonNull final List<DependencyModule> modules) {
+    this.modules = Preconditions.checkNotNull(modules, "modules");
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("target", this.target);
+    b.add("modules", this.modules);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DependencyModulesItem other = (DependencyModulesItem) obj;
+    if (this.target == null) {
+      if (other.target != null)
+        return false;
+    } else if (!this.target.equals(other.target))
+      return false;
+    if (this.modules == null) {
+      if (other.modules != null)
+        return false;
+    } else if (!this.modules.equals(other.modules))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.target== null) ? 0 : this.target.hashCode());
+    return prime * result + ((this.modules== null) ? 0 : this.modules.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencyModulesParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencyModulesParams.java
@@ -1,0 +1,60 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class DependencyModulesParams {
+  @NonNull
+  private List<BuildTargetIdentifier> targets;
+  
+  public DependencyModulesParams(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getTargets() {
+    return this.targets;
+  }
+  
+  public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = Preconditions.checkNotNull(targets, "targets");
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DependencyModulesParams other = (DependencyModulesParams) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.targets== null) ? 0 : this.targets.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencyModulesResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencyModulesResult.java
@@ -1,0 +1,60 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.DependencyModulesItem;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class DependencyModulesResult {
+  @NonNull
+  private List<DependencyModulesItem> items;
+  
+  public DependencyModulesResult(@NonNull final List<DependencyModulesItem> items) {
+    this.items = items;
+  }
+  
+  @Pure
+  @NonNull
+  public List<DependencyModulesItem> getItems() {
+    return this.items;
+  }
+  
+  public void setItems(@NonNull final List<DependencyModulesItem> items) {
+    this.items = Preconditions.checkNotNull(items, "items");
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("items", this.items);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DependencyModulesResult other = (DependencyModulesResult) obj;
+    if (this.items == null) {
+      if (other.items != null)
+        return false;
+    } else if (!this.items.equals(other.items))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.items== null) ? 0 : this.items.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/MavenDependencyModule.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/MavenDependencyModule.java
@@ -1,0 +1,143 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.MavenDependencyModuleArtifact;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class MavenDependencyModule {
+  @NonNull
+  private String organization;
+  
+  @NonNull
+  private String name;
+  
+  @NonNull
+  private String version;
+  
+  @NonNull
+  private List<MavenDependencyModuleArtifact> artifacts;
+  
+  private String scope;
+  
+  public MavenDependencyModule(@NonNull final String organization, @NonNull final String name, @NonNull final String version, @NonNull final List<MavenDependencyModuleArtifact> artifacts) {
+    this.organization = organization;
+    this.name = name;
+    this.version = version;
+    this.artifacts = artifacts;
+  }
+  
+  @Pure
+  @NonNull
+  public String getOrganization() {
+    return this.organization;
+  }
+  
+  public void setOrganization(@NonNull final String organization) {
+    this.organization = Preconditions.checkNotNull(organization, "organization");
+  }
+  
+  @Pure
+  @NonNull
+  public String getName() {
+    return this.name;
+  }
+  
+  public void setName(@NonNull final String name) {
+    this.name = Preconditions.checkNotNull(name, "name");
+  }
+  
+  @Pure
+  @NonNull
+  public String getVersion() {
+    return this.version;
+  }
+  
+  public void setVersion(@NonNull final String version) {
+    this.version = Preconditions.checkNotNull(version, "version");
+  }
+  
+  @Pure
+  @NonNull
+  public List<MavenDependencyModuleArtifact> getArtifacts() {
+    return this.artifacts;
+  }
+  
+  public void setArtifacts(@NonNull final List<MavenDependencyModuleArtifact> artifacts) {
+    this.artifacts = Preconditions.checkNotNull(artifacts, "artifacts");
+  }
+  
+  @Pure
+  public String getScope() {
+    return this.scope;
+  }
+  
+  public void setScope(final String scope) {
+    this.scope = scope;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("organization", this.organization);
+    b.add("name", this.name);
+    b.add("version", this.version);
+    b.add("artifacts", this.artifacts);
+    b.add("scope", this.scope);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    MavenDependencyModule other = (MavenDependencyModule) obj;
+    if (this.organization == null) {
+      if (other.organization != null)
+        return false;
+    } else if (!this.organization.equals(other.organization))
+      return false;
+    if (this.name == null) {
+      if (other.name != null)
+        return false;
+    } else if (!this.name.equals(other.name))
+      return false;
+    if (this.version == null) {
+      if (other.version != null)
+        return false;
+    } else if (!this.version.equals(other.version))
+      return false;
+    if (this.artifacts == null) {
+      if (other.artifacts != null)
+        return false;
+    } else if (!this.artifacts.equals(other.artifacts))
+      return false;
+    if (this.scope == null) {
+      if (other.scope != null)
+        return false;
+    } else if (!this.scope.equals(other.scope))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.organization== null) ? 0 : this.organization.hashCode());
+    result = prime * result + ((this.name== null) ? 0 : this.name.hashCode());
+    result = prime * result + ((this.version== null) ? 0 : this.version.hashCode());
+    result = prime * result + ((this.artifacts== null) ? 0 : this.artifacts.hashCode());
+    return prime * result + ((this.scope== null) ? 0 : this.scope.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/MavenDependencyModuleArtifact.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/MavenDependencyModuleArtifact.java
@@ -1,0 +1,78 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class MavenDependencyModuleArtifact {
+  @NonNull
+  private String uri;
+  
+  private String classifier;
+  
+  public MavenDependencyModuleArtifact(@NonNull final String uri) {
+    this.uri = uri;
+  }
+  
+  @Pure
+  @NonNull
+  public String getUri() {
+    return this.uri;
+  }
+  
+  public void setUri(@NonNull final String uri) {
+    this.uri = Preconditions.checkNotNull(uri, "uri");
+  }
+  
+  @Pure
+  public String getClassifier() {
+    return this.classifier;
+  }
+  
+  public void setClassifier(final String classifier) {
+    this.classifier = classifier;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("uri", this.uri);
+    b.add("classifier", this.classifier);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    MavenDependencyModuleArtifact other = (MavenDependencyModuleArtifact) obj;
+    if (this.uri == null) {
+      if (other.uri != null)
+        return false;
+    } else if (!this.uri.equals(other.uri))
+      return false;
+    if (this.classifier == null) {
+      if (other.classifier != null)
+        return false;
+    } else if (!this.classifier.equals(other.classifier))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.uri== null) ? 0 : this.uri.hashCode());
+    return prime * result + ((this.classifier== null) ? 0 : this.classifier.hashCode());
+  }
+}

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -129,6 +129,7 @@ object BuildTargetDataKind {
     debugProvider: Option[DebugProvider],
     inverseSourcesProvider: Option[Boolean],
     dependencySourcesProvider: Option[Boolean],
+    dependencyModulesProvider: Option[Boolean],
     resourcesProvider: Option[Boolean],
     buildTargetChangedProvider: Option[Boolean],
     jvmTestEnvironmentProvider: Option[Boolean],
@@ -356,6 +357,43 @@ object SourceItemKind {
 
 @JsonCodec final case class DependencySourcesResult(
     items: List[DependencySourcesItem]
+)
+
+@JsonCodec final case class DependencyModulesParams(
+    targets: List[BuildTargetIdentifier]
+)
+
+@JsonCodec final case class DependencyModule(
+  name: String,
+  version: String,
+  dataKind: Option[String],
+  data: Option[Json]
+)
+
+object DependencyModuleDataKind {
+  val maven = "maven"
+}
+
+@JsonCodec final case class DependencyModulesItem(
+  target: BuildTargetIdentifier,
+  modules: List[DependencyModule]
+)
+
+@JsonCodec final case class DependencyModulesResult(
+  items: List[DependencyModulesItem]
+)
+
+@JsonCodec final case class MavenDependencyModuleArtifact(
+  uri: String,
+  classifier: Option[String],
+)
+
+@JsonCodec final case class MavenDependencyModule(
+  organization: String,
+  name: String,
+  version: String,
+  artifacts: List[MavenDependencyModuleArtifact],
+  scope: Option[String]
 )
 
 // Request: 'buildTarget/resources', C -> S

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
@@ -34,6 +34,7 @@ trait BuildTarget {
   object dependencySources
       extends Endpoint[DependencySourcesParams, DependencySourcesResult](
         "buildTarget/dependencySources")
+  object dependencyModules extends Endpoint[DependencyModulesParams, DependencyModulesResult]("buildTarget/dependencyModules")
   object resources extends Endpoint[ResourcesParams, ResourcesResult]("buildTarget/resources")
 
   // Scala specific endpoints

--- a/docs/bindings/java.md
+++ b/docs/bindings/java.md
@@ -164,6 +164,7 @@ class MyBuildServer extends BuildServer {
   def buildTargetCleanCache(params: CleanCacheParams): CompletableFuture[CleanCacheResult] = ???
   def buildTargetCompile(params: CompileParams): CompletableFuture[CompileResult] = ???
   def buildTargetDependencySources(params: DependencySourcesParams): CompletableFuture[DependencySourcesResult] = ???
+  def buildTargetDependencyModules(params: DependencyModulesParams): CompletableFuture[DependencyModulesResult] = ???
   def buildTargetInverseSources(params: InverseSourcesParams): CompletableFuture[InverseSourcesResult] = ???
   def buildTargetResources(params: ResourcesParams): CompletableFuture[ResourcesResult] = ???
   def buildTargetRun(params: RunParams): CompletableFuture[RunResult] = ???

--- a/docs/extensions/maven.md
+++ b/docs/extensions/maven.md
@@ -1,0 +1,34 @@
+---
+id: maven
+title: Maven Extension
+sidebar_label: Maven
+---
+
+### Maven Dependency Module
+
+`MavenDependencyModule` is a basic data structure that contains maven-like
+metadata. This metadata is embedded in the `data: Option[Json]` field of the `DependencyModule` definition, when the `dataKind` field contains "maven".
+
+```ts
+export interface MavenDependencyModule {
+  organization: String;
+  name: String;
+  version: String;
+  scope?: String
+
+  /** List of module's artifacts with different classifiers.
+     For example: [
+       {uri = "../scala-library-2.13.5.jar"},
+       {uri = "../scala-library-2.13.5-sources.jar", classifier = "sources"}
+     ]*/
+  artifacts: MavenDependencyModuleArtifact[];
+}
+
+export interface MavenDependencyModuleArtifact {
+  /** Path to jar*/
+  uri: Uri;
+
+  /** Empty or `sources`|`docs` */
+  classifier?: String
+}
+```

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -382,6 +382,10 @@ export interface BuildServerCapabilities {
    * via method buildTarget/dependencySources */
   dependencySourcesProvider?: Boolean;
 
+  /** The server cam provide a list of dependency modules (libraries with meta information)
+   * via method buildTarget/dependencyModules */
+  dependencyModulesProvider?: Boolean;
+
   /** The server provides all the resource dependencies
    * via method buildTarget/resources */
   resourcesProvider?: Boolean;
@@ -810,6 +814,50 @@ export interface DependencySourcesItem {
    * target's dependencies.
    * Can be source files, jar files, zip files, or directories. */
   sources: Uri[];
+}
+```
+
+### Dependency Modules Request
+
+The build target dependency modules request is sent from the client to the
+server to query for the libraries of build target dependencies that are external
+to the workspace including meta information about library and their sources.
+It's an extended version of `buildTarget/sources`.
+
+- method: `buildTarget/dependencyModules`
+- params: `DependencyModulesParams`
+
+```ts
+export interface DependencyModulesParams {
+  targets: BuildTargetIdentifier[];
+}
+```
+
+Response:
+
+- result: `DependencyModulesResult`, defined as follows
+
+```ts
+export interface DependencyModulesResult {
+  items: DependencyModulesItem[];
+}
+export interface DependencyModulesItem {
+  target: BuildTargetIdentifier;
+  modules: DependencyModule[];
+}
+export interface DependencyModule {
+  /** Module name */
+  name: String;
+
+  /** Module version */
+  version: String;
+
+  /** Kind of data to expect in the `data` field. If this field is not set, the kind of data is not specified. */
+  dataKind?: String;
+
+  /** Language-specific metadata about this module.
+   * See MavenDependencyModule as an example. */
+  data?: any;
 }
 ```
 

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
@@ -30,6 +30,7 @@ trait Bsp4jGenerators {
     debugProvider <- genDebugProvider.nullable
     inverseSourcesProvider <- BoxedGen.boolean.nullable
     dependencySourcesProvider <- BoxedGen.boolean.nullable
+    dependencyModulesProvider <- BoxedGen.boolean.nullable
     resourcesProvider <- BoxedGen.boolean.nullable
     buildTargetChangedProvider <- BoxedGen.boolean.nullable
     canReload <- BoxedGen.boolean.nullable
@@ -43,6 +44,7 @@ trait Bsp4jGenerators {
     capabilities.setResourcesProvider(resourcesProvider)
     capabilities.setBuildTargetChangedProvider(buildTargetChangedProvider)
     capabilities.setCanReload(canReload)
+    capabilities.setDependencyModulesProvider(dependencyModulesProvider)
     capabilities
   }
 

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jShrinkers.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jShrinkers.scala
@@ -38,6 +38,7 @@ trait Bsp4jShrinkers extends UtilShrinkers {
       debugProvider <- shrink(capabilities.getDebugProvider)
       inverseSourcesProvider <- shrink(capabilities.getInverseSourcesProvider)
       dependencySourcesProvider <- shrink(capabilities.getDependencySourcesProvider)
+      dependencyModulesProvider <- shrink(capabilities.getDependencyModulesProvider)
       resourcesProvider <- shrink(capabilities.getResourcesProvider)
       buildTargetChangedProvider <- shrink(capabilities.getBuildTargetChangedProvider)
     } yield {
@@ -49,6 +50,7 @@ trait Bsp4jShrinkers extends UtilShrinkers {
       capabilities.setDependencySourcesProvider(dependencySourcesProvider)
       capabilities.setResourcesProvider(resourcesProvider)
       capabilities.setBuildTargetChangedProvider(buildTargetChangedProvider)
+      capabilities.setDependencyModulesProvider(dependencyModulesProvider)
       capabilities
     }
   }

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -20,6 +20,10 @@
         "title": "JVM Extension",
         "sidebar_label": "JVM"
       },
+      "extensions/maven": {
+        "title": "Maven Extension",
+        "sidebar_label": "Maven"
+      },
       "extensions/sbt": {
         "title": "sbt Extension",
         "sidebar_label": "sbt"


### PR DESCRIPTION
Based on #164 proposal. 

Adds the new BSP method - `buildTarget/dependencyModules`
It's a kind of extended version of  `buildTarget/sources` that has attached metadata about dependency libraries.

The only difference with the original proposal is that all JVM-specific data (org, classifiers) from DependencyModule is moved into the JVM extension.