### PR TITLE
Add data field comparisons to workspace build targets testkit

### DIFF
--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/TestClient.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/TestClient.scala
@@ -537,19 +537,8 @@ class TestClient(
       case List(foundJvmTarget: JvmBuildTarget, targetJvmTarget: JvmBuildTarget) =>
         targetJvmTarget == foundJvmTarget
       case List(foundSbtTarget: SbtBuildTarget, targetSbtTarget: SbtBuildTarget) =>
-        compareSbtBuildTargets(foundSbtTarget, targetSbtTarget)
+        targetSbtTarget == foundSbtTarget
     }
-
-  private def compareSbtBuildTargets(foundSbtTarget: SbtBuildTarget, targetSbtTarget: SbtBuildTarget) = {
-    targetSbtTarget.getAutoImports == foundSbtTarget.getAutoImports &&
-      targetSbtTarget.getChildren == foundSbtTarget.getChildren &&
-      targetSbtTarget.getParent == foundSbtTarget.getParent &&
-      targetSbtTarget.getSbtVersion == foundSbtTarget.getSbtVersion &&
-      targetSbtTarget.getClasspath.forall {
-        classpath => foundSbtTarget.getClasspath.exists(_.contains(classpath))
-      } &&
-      compareBuildTargetData(foundSbtTarget.getScalaBuildTarget, targetSbtTarget.getScalaBuildTarget)
-  }
 
   private def compareScalaBuildTargets(foundScalaTarget: ScalaBuildTarget, targetScalaTarget: ScalaBuildTarget) = {
     targetScalaTarget.getJars.forall {

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/TestClient.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/TestClient.scala
@@ -535,10 +535,23 @@ class TestClient(
       case List(foundScalaTarget: ScalaBuildTarget, targetScalaTarget: ScalaBuildTarget) =>
         compareScalaBuildTargets(foundScalaTarget, targetScalaTarget)
       case List(foundJvmTarget: JvmBuildTarget, targetJvmTarget: JvmBuildTarget) =>
-        targetJvmTarget == foundJvmTarget
+        compareJvmTarget(foundJvmTarget, targetJvmTarget)
       case List(foundSbtTarget: SbtBuildTarget, targetSbtTarget: SbtBuildTarget) =>
-        targetSbtTarget == foundSbtTarget
+        compareSbtBuildTarget(foundSbtTarget, targetSbtTarget)
     }
+
+  private def compareSbtBuildTarget(foundSbtTarget: SbtBuildTarget, targetSbtTarget: SbtBuildTarget) = {
+    targetSbtTarget.getAutoImports == foundSbtTarget.getAutoImports &&
+      targetSbtTarget.getChildren == foundSbtTarget.getChildren &&
+      targetSbtTarget.getParent == foundSbtTarget.getParent &&
+      targetSbtTarget.getSbtVersion == foundSbtTarget.getSbtVersion &&
+      compareScalaBuildTargets(foundSbtTarget.getScalaBuildTarget, targetSbtTarget.getScalaBuildTarget)
+  }
+
+  private def compareJvmTarget(foundJvmTarget: JvmBuildTarget, targetJvmTarget: JvmBuildTarget) = {
+    foundJvmTarget.getJavaHome.contains(targetJvmTarget.getJavaHome) &&
+      targetJvmTarget.getJavaVersion == foundJvmTarget.getJavaVersion
+  }
 
   private def compareScalaBuildTargets(foundScalaTarget: ScalaBuildTarget, targetScalaTarget: ScalaBuildTarget) = {
     targetScalaTarget.getJars.forall {
@@ -548,7 +561,7 @@ class TestClient(
       targetScalaTarget.getScalaBinaryVersion == foundScalaTarget.getScalaBinaryVersion &&
       targetScalaTarget.getScalaOrganization == foundScalaTarget.getScalaOrganization &&
       targetScalaTarget.getScalaVersion == foundScalaTarget.getScalaVersion &&
-      compareBuildTargetData(foundScalaTarget.getJvmBuildTarget, targetScalaTarget.getJvmBuildTarget)
+      compareJvmTarget(foundScalaTarget.getJvmBuildTarget, targetScalaTarget.getJvmBuildTarget)
   }
 
   private def compareBuildTargets(

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
@@ -218,6 +218,10 @@ class HappyMockServer(base: File) extends AbstractMockServer {
       val scalaBuildTarget =
         new ScalaBuildTarget("org.scala-lang", "2.12.7", "2.12", ScalaPlatform.JVM, scalaJars)
       scalaBuildTarget.setJvmBuildTarget(jvmBuildTarget)
+      val autoImports = List("task-key").asJava
+      val children = List(targetId3).asJava
+      val sbtBuildTarget =
+        new SbtBuildTarget("1.0.0", autoImports, scalaBuildTarget, children)
 
       target1.setDisplayName("target 1")
       target1.setBaseDirectory(targetId1.getUri)
@@ -226,13 +230,13 @@ class HappyMockServer(base: File) extends AbstractMockServer {
 
       target2.setDisplayName("target 2")
       target2.setBaseDirectory(targetId2.getUri)
-      target2.setDataKind(BuildTargetDataKind.SCALA)
-      target2.setData(scalaBuildTarget)
+      target2.setDataKind(BuildTargetDataKind.JVM)
+      target2.setData(jvmBuildTarget)
 
       target3.setDisplayName("target 3")
       target3.setBaseDirectory(targetId3.getUri)
-      target3.setDataKind(BuildTargetDataKind.SCALA)
-      target3.setData(scalaBuildTarget)
+      target3.setDataKind(BuildTargetDataKind.SBT)
+      target3.setData(sbtBuildTarget)
 
       val result = new WorkspaceBuildTargetsResult(compileTargets.values.toList.asJava)
       Right(result)

--- a/tests/src/test/scala/tests/MockClientSuite.scala
+++ b/tests/src/test/scala/tests/MockClientSuite.scala
@@ -228,22 +228,26 @@ class MockClientSuite extends FunSuite {
     val scalaJars = List("scala-compiler.jar", "scala-reflect.jar", "scala-library.jar").asJava
     val scalaBuildTarget =
       new ScalaBuildTarget("org.scala-lang", "2.12.7", "2.12", ScalaPlatform.JVM, scalaJars)
-
     scalaBuildTarget.setJvmBuildTarget(jvmBuildTarget)
-    target2.setDisplayName("target 1")
+    val autoImports = List("task-key").asJava
+    val children = List(targetId3).asJava
+    val sbtBuildTarget =
+      new SbtBuildTarget("1.0.0", autoImports, scalaBuildTarget, children)
+
+    target1.setDisplayName("target 1")
     target1.setBaseDirectory(targetId1.getUri)
     target1.setDataKind(BuildTargetDataKind.SCALA)
     target1.setData(scalaBuildTarget)
 
     target2.setDisplayName("target 2")
     target2.setBaseDirectory(targetId2.getUri)
-    target2.setDataKind(BuildTargetDataKind.SCALA)
-    target2.setData(scalaBuildTarget)
+    target2.setDataKind(BuildTargetDataKind.JVM)
+    target2.setData(jvmBuildTarget)
 
     target3.setDisplayName("target 3")
     target3.setBaseDirectory(targetId3.getUri)
-    target3.setDataKind(BuildTargetDataKind.SCALA)
-    target3.setData(scalaBuildTarget)
+    target3.setDataKind(BuildTargetDataKind.SBT)
+    target3.setData(sbtBuildTarget)
 
     val workspaceBuildTargetsResult = new WorkspaceBuildTargetsResult(targets)
     client.testCompareWorkspaceTargetsResults(workspaceBuildTargetsResult)


### PR DESCRIPTION
The client testkit didn't provide a means of testing the `data` field of the workspace build target. This PR aims to change that.