### PR TITLE
Remove classpath from sbt build target

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/SbtExtension.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/SbtExtension.xtend
@@ -8,12 +8,11 @@ import org.eclipse.lsp4j.generator.JsonRpcData
 class SbtBuildTarget {
   @NonNull String sbtVersion
   @NonNull List<String> autoImports
-  @NonNull List<String> classpath
   @NonNull ScalaBuildTarget scalaBuildTarget
   BuildTargetIdentifier parent
   @NonNull List<BuildTargetIdentifier> children
-  new(@NonNull String sbtVersion, @NonNull List<String> autoImports, @NonNull List<String> classpath,
-      @NonNull ScalaBuildTarget scalaBuildTarget, @NonNull List<BuildTargetIdentifier> children) {
+  new(@NonNull String sbtVersion, @NonNull List<String> autoImports,@NonNull ScalaBuildTarget scalaBuildTarget,
+      @NonNull List<BuildTargetIdentifier> children) {
     this.sbtVersion = sbtVersion
     this.autoImports = autoImports
     this.scalaBuildTarget = scalaBuildTarget

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/SbtBuildTarget.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/SbtBuildTarget.java
@@ -17,9 +17,6 @@ public class SbtBuildTarget {
   private List<String> autoImports;
   
   @NonNull
-  private List<String> classpath;
-  
-  @NonNull
   private ScalaBuildTarget scalaBuildTarget;
   
   private BuildTargetIdentifier parent;
@@ -27,7 +24,7 @@ public class SbtBuildTarget {
   @NonNull
   private List<BuildTargetIdentifier> children;
   
-  public SbtBuildTarget(@NonNull final String sbtVersion, @NonNull final List<String> autoImports, @NonNull final List<String> classpath, @NonNull final ScalaBuildTarget scalaBuildTarget, @NonNull final List<BuildTargetIdentifier> children) {
+  public SbtBuildTarget(@NonNull final String sbtVersion, @NonNull final List<String> autoImports, @NonNull final ScalaBuildTarget scalaBuildTarget, @NonNull final List<BuildTargetIdentifier> children) {
     this.sbtVersion = sbtVersion;
     this.autoImports = autoImports;
     this.scalaBuildTarget = scalaBuildTarget;
@@ -52,16 +49,6 @@ public class SbtBuildTarget {
   
   public void setAutoImports(@NonNull final List<String> autoImports) {
     this.autoImports = Preconditions.checkNotNull(autoImports, "autoImports");
-  }
-  
-  @Pure
-  @NonNull
-  public List<String> getClasspath() {
-    return this.classpath;
-  }
-  
-  public void setClasspath(@NonNull final List<String> classpath) {
-    this.classpath = Preconditions.checkNotNull(classpath, "classpath");
   }
   
   @Pure
@@ -99,7 +86,6 @@ public class SbtBuildTarget {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("sbtVersion", this.sbtVersion);
     b.add("autoImports", this.autoImports);
-    b.add("classpath", this.classpath);
     b.add("scalaBuildTarget", this.scalaBuildTarget);
     b.add("parent", this.parent);
     b.add("children", this.children);
@@ -126,11 +112,6 @@ public class SbtBuildTarget {
         return false;
     } else if (!this.autoImports.equals(other.autoImports))
       return false;
-    if (this.classpath == null) {
-      if (other.classpath != null)
-        return false;
-    } else if (!this.classpath.equals(other.classpath))
-      return false;
     if (this.scalaBuildTarget == null) {
       if (other.scalaBuildTarget != null)
         return false;
@@ -156,7 +137,6 @@ public class SbtBuildTarget {
     int result = 1;
     result = prime * result + ((this.sbtVersion== null) ? 0 : this.sbtVersion.hashCode());
     result = prime * result + ((this.autoImports== null) ? 0 : this.autoImports.hashCode());
-    result = prime * result + ((this.classpath== null) ? 0 : this.classpath.hashCode());
     result = prime * result + ((this.scalaBuildTarget== null) ? 0 : this.scalaBuildTarget.hashCode());
     result = prime * result + ((this.parent== null) ? 0 : this.parent.hashCode());
     return prime * result + ((this.children== null) ? 0 : this.children.hashCode());

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
@@ -322,12 +322,11 @@ trait Bsp4jGenerators {
   lazy val genSbtBuildTarget: Gen[SbtBuildTarget] = for {
     sbtVersion <- arbitrary[String]
     autoImports <- arbitrary[String].list
-    classpath <- arbitrary[String].list
     scalaBuildTarget <- genScalaBuildTarget
     children <- genBuildTargetIdentifier.list
     parent <- genBuildTargetIdentifier.nullable
   } yield {
-    val target = new SbtBuildTarget(sbtVersion, autoImports, classpath, scalaBuildTarget, children)
+    val target = new SbtBuildTarget(sbtVersion, autoImports, scalaBuildTarget, children)
     target.setParent(parent)
     target
   }

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jShrinkers.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jShrinkers.scala
@@ -339,12 +339,11 @@ trait Bsp4jShrinkers extends UtilShrinkers {
     for {
       sbtVersion <- shrink(a.getSbtVersion)
       autoImports <- shrink(a.getAutoImports)
-      classpath <- shrink(a.getClasspath)
       scalaBuildTarget <- shrink(a.getScalaBuildTarget)
       children <- shrink(a.getChildren)
       parent <- shrink(a.getParent)
     } yield {
-      val target = new SbtBuildTarget(sbtVersion, autoImports, classpath, scalaBuildTarget, children)
+      val target = new SbtBuildTarget(sbtVersion, autoImports, scalaBuildTarget, children)
       target.setParent(parent)
       target
     }
@@ -392,7 +391,7 @@ trait Bsp4jShrinkers extends UtilShrinkers {
       val mainClass = new ScalaMainClass(className, arguments, jvmOptions)
       mainClass.setEnvironmentVariables(environmentVariables)
       mainClass
-    } 
+    }
   }
 
   implicit def shrinkScalaMainClassesItem: Shrink[ScalaMainClassesItem] = Shrink { a =>


### PR DESCRIPTION
The classpath had previously been removed from the `SbtBuildTarget` but it was still available through the constructor of the java version.