### PR TITLE
Upgrade bsp4s to use jsonrpc4s and jsoniter-scala directly

### DIFF
--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -2,11 +2,14 @@ package ch.epfl.scala.bsp
 
 import java.net.{URI, URISyntaxException}
 
-import io.circe.Decoder.Result
-import io.circe._
-import io.circe.derivation.JsonCodec
-import io.circe.generic.extras._
-import io.circe.generic.extras.semiauto.{deriveDecoder, deriveEncoder}
+import ch.epfl.scala.bsp.BuildTargetEventKind.{Changed, Created, Deleted}
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonCodec
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonReader
+import com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig
+import jsonrpc4s.RawJson
 
 final case class Uri private[Uri] (val value: String) {
   def toPath: java.nio.file.Path =
@@ -17,36 +20,37 @@ object Uri {
   // This is the only valid way to create a URI
   def apply(u: URI): Uri = Uri(u.toString)
 
-  implicit val uriEncoder: RootEncoder[Uri] = new RootEncoder[Uri] {
-    override def apply(a: Uri): Json = Json.fromString(a.value)
-  }
-
-  implicit val uriDecoder: Decoder[Uri] = new Decoder[Uri] {
-    // Should we add validation here
-    override def apply(c: HCursor): Result[Uri] = {
-      c.as[String].flatMap { str =>
-        try Right(Uri(URI.create(str).toString))
-        catch {
-          case _: IllegalArgumentException | _: URISyntaxException =>
-            Left(DecodingFailure(s"String $str is not a valid URI.", c.history))
-        }
+  implicit val uriCodec: JsonValueCodec[Uri] = new JsonValueCodec[Uri] {
+    def nullValue: Uri = null
+    def encodeValue(id: Uri, out: JsonWriter): Unit = out.writeVal(id.value)
+    def decodeValue(in: JsonReader, default: Uri): Uri = {
+      val defaultStr = if (default == null) null else default.value
+      val str = in.readString(defaultStr)
+      try Uri(URI.create(str).toString)
+      catch {
+        case _: IllegalArgumentException | _: URISyntaxException =>
+          in.decodeError(s"String $str is not a valid URI!")
       }
     }
   }
 }
 
-@JsonCodec final case class TextDocumentIdentifier(
+final case class TextDocumentIdentifier(
     uri: Uri
 )
 
-@JsonCodec final case class BuildTargetIdentifier(
+object TextDocumentIdentifier {
+  implicit val codec: JsonValueCodec[TextDocumentIdentifier] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class BuildTargetIdentifier(
     uri: Uri
 )
 
-object BuildTargetCapabilities {
-  implicit val config: Configuration = Configuration.default.withDefaults
-  implicit val jsonDecoder: Decoder[BuildTargetCapabilities] = deriveDecoder
-  implicit val jsonEncoder: Encoder[BuildTargetCapabilities] = deriveEncoder
+object BuildTargetIdentifier {
+  implicit val codec: JsonValueCodec[BuildTargetIdentifier] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
 }
 
 final case class BuildTargetCapabilities(
@@ -55,6 +59,11 @@ final case class BuildTargetCapabilities(
     canRun: Boolean,
     canDebug: Boolean = false, // backward compatible default
 )
+
+object BuildTargetCapabilities {
+  implicit val codec: JsonValueCodec[BuildTargetCapabilities] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
 object BuildTargetTag {
   val Library = "library"
@@ -66,7 +75,7 @@ object BuildTargetTag {
   val Manual = "manual"
 }
 
-@JsonCodec final case class BuildTarget(
+final case class BuildTarget(
     id: BuildTargetIdentifier,
     displayName: Option[String],
     baseDirectory: Option[Uri],
@@ -75,54 +84,109 @@ object BuildTargetTag {
     languageIds: List[String],
     dependencies: List[BuildTargetIdentifier],
     dataKind: Option[String],
-    data: Option[Json]
+    data: Option[RawJson]
 )
+
+object BuildTarget {
+  implicit val codec: JsonValueCodec[BuildTarget] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
 object BuildTargetDataKind {
   val Scala = "scala"
   val Sbt = "sbt"
 }
 
-@JsonCodec final case class BuildClientCapabilities(
+final case class BuildClientCapabilities(
     languageIds: List[String]
 )
 
+object BuildClientCapabilities {
+  implicit val codec: JsonValueCodec[BuildClientCapabilities] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
 // Notification: 'build/initialized', C -> S
-@JsonCodec final case class InitializedBuildParams()
+final case class InitializedBuildParams()
+
+object InitializedBuildParams {
+  implicit val codec: JsonValueCodec[InitializedBuildParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
 // Request: 'build/initialize', C -> S
-@JsonCodec final case class InitializeBuildParams(
+final case class InitializeBuildParams(
     displayName: String,
     version: String,
     bspVersion: String,
     rootUri: Uri,
     capabilities: BuildClientCapabilities,
-    data: Option[Json]
+    data: Option[RawJson]
 )
 
-@JsonCodec final case class Reload()
+object InitializeBuildParams {
+  implicit val codec: JsonValueCodec[InitializeBuildParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
-@JsonCodec final case class Shutdown()
+final case class Reload()
 
-@JsonCodec final case class Exit()
+object Reload {
+  implicit val codec: JsonValueCodec[Reload] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
-@JsonCodec final case class CompileProvider(
+final case class Shutdown()
+
+object Shutdown {
+  implicit val codec: JsonValueCodec[Shutdown] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class Exit()
+
+object Exit {
+  implicit val codec: JsonValueCodec[Exit] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class CompileProvider(
     languageIds: List[String]
 )
 
-@JsonCodec final case class TestProvider(
+object CompileProvider {
+  implicit val codec: JsonValueCodec[CompileProvider] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class TestProvider(
     languageIds: List[String]
 )
 
-@JsonCodec final case class RunProvider(
+object TestProvider {
+  implicit val codec: JsonValueCodec[TestProvider] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class RunProvider(
     languageIds: List[String]
 )
 
-@JsonCodec final case class DebugProvider(
+object RunProvider {
+  implicit val codec: JsonValueCodec[RunProvider] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class DebugProvider(
   languageIds: List[String]
 )
 
-@JsonCodec final case class BuildServerCapabilities(
+object DebugProvider {
+  implicit val codec: JsonValueCodec[DebugProvider] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class BuildServerCapabilities(
     compileProvider: Option[CompileProvider],
     testProvider: Option[TestProvider],
     runProvider: Option[RunProvider],
@@ -137,13 +201,23 @@ object BuildTargetDataKind {
     canReload: Option[Boolean],
 )
 
-@JsonCodec final case class InitializeBuildResult(
+object BuildServerCapabilities {
+  implicit val codec: JsonValueCodec[BuildServerCapabilities] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class InitializeBuildResult(
     displayName: String,
     version: String,
     bspVersion: String,
     capabilities: BuildServerCapabilities,
-    data: Option[Json]
+    data: Option[RawJson]
 )
+
+object InitializeBuildResult {
+  implicit val codec: JsonValueCodec[InitializeBuildResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
 sealed abstract class MessageType(val id: Int)
 object MessageType {
@@ -152,56 +226,83 @@ object MessageType {
   case object Info extends MessageType(3)
   case object Log extends MessageType(4)
 
-  implicit val messageTypeEncoder: RootEncoder[MessageType] = new RootEncoder[MessageType] {
-    override def apply(a: MessageType): Json = Json.fromInt(a.id)
-  }
-
-  implicit val messageTypeDecoder: Decoder[MessageType] = new Decoder[MessageType] {
-    override def apply(c: HCursor): Result[MessageType] = {
-      c.as[Int].flatMap {
-        case 1 => Right(Error)
-        case 2 => Right(Warning)
-        case 3 => Right(Info)
-        case 4 => Right(Log)
-        case n => Left(DecodingFailure(s"Unknown message type id for $n", c.history))
+  implicit val codec: JsonValueCodec[MessageType] = new JsonValueCodec[MessageType] {
+    def nullValue: MessageType = null
+    def encodeValue(msg: MessageType, out: JsonWriter): Unit = out.writeVal(msg.id)
+    def decodeValue(in: JsonReader, default: MessageType): MessageType = {
+      in.readInt() match {
+        case 1 => Error
+        case 2 => Warning
+        case 3 => Info
+        case 4 => Log
+        case n => in.decodeError(s"Unknown message type id for $n")
       }
     }
   }
 }
 
-@JsonCodec final case class TaskId(
+final case class TaskId(
     id: String,
     parents: Option[List[String]]
 )
 
-@JsonCodec final case class ShowMessageParams(
+object TaskId {
+  implicit val codec: JsonValueCodec[TaskId] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class ShowMessageParams(
     `type`: MessageType,
     task: Option[TaskId],
     originId: Option[String],
     message: String
 )
 
-@JsonCodec final case class LogMessageParams(
+object ShowMessageParams {
+  implicit val codec: JsonValueCodec[ShowMessageParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class LogMessageParams(
     `type`: MessageType,
     task: Option[TaskId],
     originId: Option[String],
     message: String
 )
 
-@JsonCodec final case class Position(
+object LogMessageParams {
+  implicit val codec: JsonValueCodec[LogMessageParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class Position(
     line: Int,
     character: Int
 )
 
-@JsonCodec final case class Range(
+object Position {
+  implicit val codec: JsonValueCodec[Position] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class Range(
     start: Position,
     end: Position
 )
 
-@JsonCodec case class Location(
+object Range {
+  implicit val codec: JsonValueCodec[Range] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+case class Location(
     uri: Uri,
     range: Range
 )
+object Location {
+  implicit val codec: JsonValueCodec[Location] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
 sealed abstract class DiagnosticSeverity(val id: Int)
 object DiagnosticSeverity {
@@ -210,33 +311,33 @@ object DiagnosticSeverity {
   case object Information extends DiagnosticSeverity(3)
   case object Hint extends DiagnosticSeverity(4)
 
-  implicit val diagnosticSeverityEncoder: RootEncoder[DiagnosticSeverity] = {
-    new RootEncoder[DiagnosticSeverity] {
-      override def apply(a: DiagnosticSeverity): Json = Json.fromInt(a.id)
-    }
-  }
-
-  implicit val diagnosticSeverityDecoder: Decoder[DiagnosticSeverity] = {
-    new Decoder[DiagnosticSeverity] {
-      override def apply(c: HCursor): Result[DiagnosticSeverity] = {
-        c.as[Int].flatMap {
-          case 1 => Right(Error)
-          case 2 => Right(Warning)
-          case 3 => Right(Information)
-          case 4 => Right(Hint)
-          case n => Left(DecodingFailure(s"Unknown diagnostic severity id for $n", c.history))
-        }
+  implicit val codec: JsonValueCodec[DiagnosticSeverity] = new JsonValueCodec[DiagnosticSeverity] {
+    def nullValue: DiagnosticSeverity = null
+    def encodeValue(diagnostic: DiagnosticSeverity, out: JsonWriter): Unit =
+      out.writeVal(diagnostic.id)
+    def decodeValue(in: JsonReader, default: DiagnosticSeverity): DiagnosticSeverity = {
+      in.readInt() match {
+        case 1 => Error
+        case 2 => Warning
+        case 3 => Information
+        case 4 => Hint
+        case n => in.decodeError(s"Unknown diagnostic severity id for $n")
       }
     }
   }
 }
 
-@JsonCodec final case class DiagnosticRelatedInformation(
+final case class DiagnosticRelatedInformation(
     location: Location,
     message: String
 )
 
-@JsonCodec final case class Diagnostic(
+object DiagnosticRelatedInformation {
+  implicit val codec: JsonValueCodec[DiagnosticRelatedInformation] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class Diagnostic(
     range: Range,
     severity: Option[DiagnosticSeverity],
     code: Option[String],
@@ -245,7 +346,12 @@ object DiagnosticSeverity {
     relatedInformation: Option[DiagnosticRelatedInformation]
 )
 
-@JsonCodec final case class PublishDiagnosticsParams(
+object Diagnostic {
+  implicit val codec: JsonValueCodec[Diagnostic] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class PublishDiagnosticsParams(
     textDocument: TextDocumentIdentifier,
     buildTarget: BuildTargetIdentifier,
     originId: Option[String],
@@ -253,12 +359,27 @@ object DiagnosticSeverity {
     reset: Boolean
 )
 
-@JsonCodec final case class WorkspaceBuildTargetsRequest()
+object PublishDiagnosticsParams {
+  implicit val codec: JsonValueCodec[PublishDiagnosticsParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class WorkspaceBuildTargetsRequest()
+
+object WorkspaceBuildTargetsRequest {
+  implicit val codec: JsonValueCodec[WorkspaceBuildTargetsRequest] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
 // Request: 'workspace/buildTargets'
-@JsonCodec final case class WorkspaceBuildTargetsResult(
+final case class WorkspaceBuildTargetsResult(
     targets: List[BuildTarget]
 )
+
+object WorkspaceBuildTargetsResult {
+  implicit val codec: JsonValueCodec[WorkspaceBuildTargetsResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
 sealed abstract class BuildTargetEventKind(val id: Int)
 case object BuildTargetEventKind {
@@ -266,129 +387,206 @@ case object BuildTargetEventKind {
   case object Changed extends BuildTargetEventKind(2)
   case object Deleted extends BuildTargetEventKind(3)
 
-  implicit val buildTargetEventKindEncoder: RootEncoder[BuildTargetEventKind] =
-    new RootEncoder[BuildTargetEventKind] {
-      override def apply(a: BuildTargetEventKind): Json = Json.fromInt(a.id)
-    }
-
-  implicit val buildTargetEventKindDecoder: Decoder[BuildTargetEventKind] =
-    new Decoder[BuildTargetEventKind] {
-      override def apply(c: HCursor): Result[BuildTargetEventKind] = {
-        c.as[Int].flatMap {
-          case 1 => Right(Created)
-          case 2 => Right(Changed)
-          case 3 => Right(Deleted)
-          case n => Left(DecodingFailure(s"Unknown build target event kind id for $n", c.history))
+  implicit val codec: JsonValueCodec[BuildTargetEventKind] =
+    new JsonValueCodec[BuildTargetEventKind] {
+      def nullValue: BuildTargetEventKind = null
+      def encodeValue(kind: BuildTargetEventKind, out: JsonWriter): Unit =
+        out.writeVal(kind.id)
+      def decodeValue(in: JsonReader, default: BuildTargetEventKind): BuildTargetEventKind = {
+        in.readInt() match {
+          case 1 => Created
+          case 2 => Changed
+          case 3 => Deleted
+          case n => in.decodeError(s"Unknown build target event kind id for $n")
         }
       }
     }
 }
 
-@JsonCodec final case class BuildTargetEvent(
+final case class BuildTargetEvent(
     target: BuildTargetIdentifier,
     kind: Option[BuildTargetEventKind],
-    data: Option[Json]
+    data: Option[RawJson]
 )
 
+object BuildTargetEvent {
+  implicit val codec: JsonValueCodec[BuildTargetEvent] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
 // Notification: 'buildTarget/didChange', S -> C
-@JsonCodec final case class DidChangeBuildTarget(
+final case class DidChangeBuildTarget(
     changes: List[BuildTargetEvent]
 )
 
+object DidChangeBuildTarget {
+  implicit val codec: JsonValueCodec[DidChangeBuildTarget] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
 // Request: 'buildTarget/sources', C -> S
-@JsonCodec final case class SourcesParams(
+final case class SourcesParams(
     targets: List[BuildTargetIdentifier]
 )
 
-@JsonCodec final case class SourcesResult(
+object SourcesParams {
+  implicit val codec: JsonValueCodec[SourcesParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class SourcesResult(
     items: List[SourcesItem]
 )
-@JsonCodec final case class SourcesItem(
+
+object SourcesResult {
+  implicit val codec: JsonValueCodec[SourcesResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class SourcesItem(
     target: BuildTargetIdentifier,
     sources: List[SourceItem],
     roots: Option[List[Uri]]
 )
-@JsonCodec final case class SourceItem(
+
+object SourcesItem {
+  implicit val codec: JsonValueCodec[SourcesItem] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class SourceItem(
     uri: Uri,
     kind: SourceItemKind,
     generated: Boolean
 )
+
+object SourceItem {
+  implicit val codec: JsonValueCodec[SourceItem] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
 sealed abstract class SourceItemKind(val id: Int)
 object SourceItemKind {
   object File extends SourceItemKind(1)
   object Directory extends SourceItemKind(2)
 
-  implicit val sourceItemKindEncoder: RootEncoder[SourceItemKind] =
-    new RootEncoder[SourceItemKind] {
-      override def apply(a: SourceItemKind): Json = Json.fromInt(a.id)
-    }
-
-  implicit val sourceItemKindDecoder: Decoder[SourceItemKind] =
-    new Decoder[SourceItemKind] {
-      override def apply(c: HCursor): Result[SourceItemKind] = {
-        c.as[Int].flatMap {
-          case 1 => Right(File)
-          case 2 => Right(Directory)
-          case n => Left(DecodingFailure(s"Unknown build target event kind id for $n", c.history))
-        }
+  implicit val codec: JsonValueCodec[SourceItemKind] = new JsonValueCodec[SourceItemKind] {
+    def nullValue: SourceItemKind = null
+    def encodeValue(item: SourceItemKind, out: JsonWriter): Unit =
+      out.writeVal(item.id)
+    def decodeValue(in: JsonReader, default: SourceItemKind): SourceItemKind = {
+      in.readInt() match {
+        case 1 => File
+        case 2 => Directory
+        case n => in.decodeError(s"Unknown source item kind id for $n")
       }
     }
+  }
 }
 
 // Request: 'buildTarget/inverseSources', C -> S
-@JsonCodec final case class InverseSourcesParams(
+final case class InverseSourcesParams(
     textDocument: TextDocumentIdentifier
 )
 
-@JsonCodec final case class InverseSourcesResult(
+object InverseSourcesParams {
+  implicit val codec: JsonValueCodec[InverseSourcesParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class InverseSourcesResult(
     targets: List[BuildTargetIdentifier]
 )
+
+object InverseSourcesResult {
+  implicit val codec: JsonValueCodec[InverseSourcesResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
 // Request: 'buildTarget/dependencySources', C -> S
-@JsonCodec final case class DependencySourcesParams(
+final case class DependencySourcesParams(
     targets: List[BuildTargetIdentifier]
 )
 
-@JsonCodec final case class DependencySourcesItem(
+object DependencySourcesParams {
+  implicit val codec: JsonValueCodec[DependencySourcesParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class DependencySourcesItem(
     target: BuildTargetIdentifier,
     sources: List[Uri]
 )
 
-@JsonCodec final case class DependencySourcesResult(
+object DependencySourcesItem {
+  implicit val codec: JsonValueCodec[DependencySourcesItem] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class DependencySourcesResult(
     items: List[DependencySourcesItem]
 )
 
-@JsonCodec final case class DependencyModulesParams(
+object DependencySourcesResult {
+  implicit val codec: JsonValueCodec[DependencySourcesResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class DependencyModulesParams(
     targets: List[BuildTargetIdentifier]
 )
 
-@JsonCodec final case class DependencyModule(
+object DependencyModulesParams {
+  implicit val codec: JsonValueCodec[DependencyModulesParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class DependencyModule(
   name: String,
   version: String,
   dataKind: Option[String],
-  data: Option[Json]
+  data: Option[RawJson]
 )
+
+object DependencyModule {
+  implicit val codec: JsonValueCodec[DependencyModule] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
 object DependencyModuleDataKind {
   val maven = "maven"
 }
 
-@JsonCodec final case class DependencyModulesItem(
+final case class DependencyModulesItem(
   target: BuildTargetIdentifier,
   modules: List[DependencyModule]
 )
 
-@JsonCodec final case class DependencyModulesResult(
+object DependencyModulesItem {
+  implicit val codec: JsonValueCodec[DependencyModulesItem] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class DependencyModulesResult(
   items: List[DependencyModulesItem]
 )
 
-@JsonCodec final case class MavenDependencyModuleArtifact(
+object DependencyModulesResult {
+  implicit val codec: JsonValueCodec[DependencyModulesResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class MavenDependencyModuleArtifact(
   uri: String,
   classifier: Option[String],
 )
 
-@JsonCodec final case class MavenDependencyModule(
+object MavenDependencyModuleArtifact {
+  implicit val codec: JsonValueCodec[MavenDependencyModuleArtifact] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class MavenDependencyModule(
   organization: String,
   name: String,
   version: String,
@@ -396,35 +594,65 @@ object DependencyModuleDataKind {
   scope: Option[String]
 )
 
+object MavenDependencyModule {
+  implicit val codec: JsonValueCodec[MavenDependencyModule] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
 // Request: 'buildTarget/resources', C -> S
-@JsonCodec final case class ResourcesParams(
+final case class ResourcesParams(
     targets: List[BuildTargetIdentifier]
 )
 
-@JsonCodec final case class ResourcesResult(
+object ResourcesParams {
+  implicit val codec: JsonValueCodec[ResourcesParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class ResourcesResult(
     items: List[ResourcesItem]
 )
 
-@JsonCodec final case class ResourcesItem(
+object ResourcesResult {
+  implicit val codec: JsonValueCodec[ResourcesResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class ResourcesItem(
     target: BuildTargetIdentifier,
     resources: List[Uri]
 )
 
+object ResourcesItem {
+  implicit val codec: JsonValueCodec[ResourcesItem] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
 // Request: 'buildTarget/compile', C -> S
-@JsonCodec final case class CompileParams(
+final case class CompileParams(
     targets: List[BuildTargetIdentifier],
     originId: Option[String],
     arguments: Option[List[String]]
 )
 
-@JsonCodec final case class CompileResult(
+object CompileParams {
+  implicit val codec: JsonValueCodec[CompileParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class CompileResult(
     originId: Option[String],
     statusCode: StatusCode,
     dataKind: Option[String],
-    data: Option[Json],
+    data: Option[RawJson]
 )
 
-@JsonCodec final case class CompileReport(
+object CompileResult {
+  implicit val codec: JsonValueCodec[CompileResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class CompileReport(
     target: BuildTargetIdentifier,
     originId: Option[String],
     errors: Int,
@@ -432,26 +660,46 @@ object DependencyModuleDataKind {
     time: Option[Long]
 )
 
-@JsonCodec final case class CompileTask(
+object CompileReport {
+  implicit val codec: JsonValueCodec[CompileReport] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class CompileTask(
     target: BuildTargetIdentifier
 )
 
-@JsonCodec final case class TestParams(
+object CompileTask {
+  implicit val codec: JsonValueCodec[CompileTask] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class TestParams(
     targets: List[BuildTargetIdentifier],
     originId: Option[String],
     arguments: Option[List[String]],
     dataKind: Option[String],
-    data: Option[Json],
+    data: Option[RawJson]
 )
 
-@JsonCodec final case class TestResult(
+object TestParams {
+  implicit val codec: JsonValueCodec[TestParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class TestResult(
     originId: Option[String],
     statusCode: StatusCode,
     dataKind: Option[String],
-    data: Option[Json],
+    data: Option[RawJson]
 )
 
-@JsonCodec final case class TestReport(
+object TestResult {
+  implicit val codec: JsonValueCodec[TestResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class TestReport(
     target: BuildTargetIdentifier,
     originId: Option[String],
     passed: Int,
@@ -462,23 +710,43 @@ object DependencyModuleDataKind {
     time: Option[Long]
 )
 
-@JsonCodec final case class TestTask(
+object TestReport {
+  implicit val codec: JsonValueCodec[TestReport] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class TestTask(
     target: BuildTargetIdentifier
 )
 
-@JsonCodec final case class TestStart(
+object TestTask {
+  implicit val codec: JsonValueCodec[TestTask] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class TestStart(
     displayName: String,
     location: Option[Location]
 )
 
-@JsonCodec final case class TestFinish(
+object TestStart {
+  implicit val codec: JsonValueCodec[TestStart] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class TestFinish(
     displayName: String,
     message: Option[String],
     status: TestStatus,
     location: Option[Location],
     dataKind: Option[String],
-    data: Option[Json]
+    data: Option[RawJson]
 )
+
+object TestFinish {
+  implicit val codec: JsonValueCodec[TestFinish] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
 sealed abstract class TestStatus(val code: Int)
 object TestStatus {
@@ -488,31 +756,35 @@ object TestStatus {
   case object Cancelled extends TestStatus(4)
   case object Skipped extends TestStatus(5)
 
-  implicit val testStatusEncoder: RootEncoder[TestStatus] = new RootEncoder[TestStatus] {
-    override def apply(a: TestStatus): Json = Json.fromInt(a.code)
-  }
-
-  implicit val statusCodeDecoder: Decoder[TestStatus] = new Decoder[TestStatus] {
-    override def apply(c: HCursor): Result[TestStatus] = {
-      c.as[Int].flatMap {
-        case 1 => Right(Passed)
-        case 2 => Right(Failed)
-        case 3 => Right(Ignored)
-        case 4 => Right(Cancelled)
-        case 5 => Right(Skipped)
-        case n => Left(DecodingFailure(s"Unknown test status $n", c.history))
+  implicit val codec: JsonValueCodec[TestStatus] = new JsonValueCodec[TestStatus] {
+    def nullValue: TestStatus = null
+    def encodeValue(status: TestStatus, out: JsonWriter): Unit =
+      out.writeVal(status.code)
+    def decodeValue(in: JsonReader, default: TestStatus): TestStatus = {
+      in.readInt() match {
+        case 1 => Passed
+        case 2 => Failed
+        case 3 => Ignored
+        case 4 => Cancelled
+        case 5 => Skipped
+        case n => in.decodeError(s"Unknown test status $n")
       }
     }
   }
 }
 
-@JsonCodec final case class RunParams(
+final case class RunParams(
     target: BuildTargetIdentifier,
     originId: Option[String],
     arguments: Option[List[String]],
     dataKind: Option[String],
-    data: Option[Json],
+    data: Option[RawJson]
 )
+
+object RunParams {
+  implicit val codec: JsonValueCodec[RunParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
 object RunParamsDataKind {
   val ScalaMainClass = "scala-main-class"
@@ -524,45 +796,64 @@ object StatusCode {
   case object Error extends StatusCode(2)
   case object Cancelled extends StatusCode(3)
 
-  implicit val statusCodeEncoder: RootEncoder[StatusCode] = new RootEncoder[StatusCode] {
-    override def apply(a: StatusCode): Json = Json.fromInt(a.code)
-  }
-
-  implicit val statusCodeDecoder: Decoder[StatusCode] = new Decoder[StatusCode] {
-    override def apply(c: HCursor): Result[StatusCode] = {
-      c.as[Int].flatMap {
-        case 1 => Right(Ok)
-        case 2 => Right(Error)
-        case 3 => Right(Cancelled)
-        case n => Left(DecodingFailure(s"Unknown status code $n", c.history))
+  implicit val codec: JsonValueCodec[StatusCode] = new JsonValueCodec[StatusCode] {
+    def nullValue: StatusCode = null
+    def encodeValue(status: StatusCode, out: JsonWriter): Unit =
+      out.writeVal(status.code)
+    def decodeValue(in: JsonReader, default: StatusCode): StatusCode = {
+      in.readInt() match {
+        case 1 => Ok
+        case 2 => Error
+        case 3 => Cancelled
+        case n => in.decodeError(s"Unknown status code $n")
       }
     }
   }
 }
 
-@JsonCodec final case class RunResult(
+final case class RunResult(
     originId: Option[String],
     statusCode: StatusCode
 )
 
-@JsonCodec final case class CleanCacheParams(
-    targets: List[BuildTargetIdentifier],
+object RunResult {
+  implicit val codec: JsonValueCodec[RunResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class CleanCacheParams(
+    targets: List[BuildTargetIdentifier]
 )
 
-@JsonCodec final case class CleanCacheResult(
+object CleanCacheParams {
+  implicit val codec: JsonValueCodec[CleanCacheParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class CleanCacheResult(
     message: Option[String],
     cleaned: Boolean
 )
 
-@JsonCodec final case class TaskStartParams(
+object CleanCacheResult {
+  implicit val codec: JsonValueCodec[CleanCacheResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class TaskStartParams(
     taskId: TaskId,
     eventTime: Option[Long],
     message: Option[String],
     dataKind: Option[String],
-    data: Option[Json]
+    data: Option[RawJson]
 )
 
-@JsonCodec final case class TaskProgressParams(
+object TaskStartParams {
+  implicit val codec: JsonValueCodec[TaskStartParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class TaskProgressParams(
     taskId: TaskId,
     eventTime: Option[Long],
     message: Option[String],
@@ -570,17 +861,27 @@ object StatusCode {
     progress: Option[Long],
     unit: Option[String],
     dataKind: Option[String],
-    data: Option[Json]
+    data: Option[RawJson]
 )
 
-@JsonCodec final case class TaskFinishParams(
+object TaskProgressParams {
+  implicit val codec: JsonValueCodec[TaskProgressParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class TaskFinishParams(
     taskId: TaskId,
     eventTime: Option[Long],
     message: Option[String],
     status: StatusCode,
     dataKind: Option[String],
-    data: Option[Json]
+    data: Option[RawJson]
 )
+
+object TaskFinishParams {
+  implicit val codec: JsonValueCodec[TaskFinishParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
 object TaskDataKind {
   val CompileTask = "compile-task"
@@ -597,28 +898,32 @@ object ScalaPlatform {
   case object Js extends ScalaPlatform(2)
   case object Native extends ScalaPlatform(3)
 
-  implicit val scalaPlatformEncoder: RootEncoder[ScalaPlatform] = new RootEncoder[ScalaPlatform] {
-    override def apply(a: ScalaPlatform): Json = Json.fromInt(a.id)
-  }
-
-  implicit val scalaPlatformDecoder: Decoder[ScalaPlatform] = new Decoder[ScalaPlatform] {
-    override def apply(c: HCursor): Result[ScalaPlatform] = {
-      c.as[Int].flatMap {
-        case 1 => Right(Jvm)
-        case 2 => Right(Js)
-        case 3 => Right(Native)
-        case n => Left(DecodingFailure(s"Unknown platform id for $n", c.history))
+  implicit val codec: JsonValueCodec[ScalaPlatform] = new JsonValueCodec[ScalaPlatform] {
+    def nullValue: ScalaPlatform = null
+    def encodeValue(platform: ScalaPlatform, out: JsonWriter): Unit =
+      out.writeVal(platform.id)
+    def decodeValue(in: JsonReader, default: ScalaPlatform): ScalaPlatform = {
+      in.readInt() match {
+        case 1 => Jvm
+        case 2 => Js
+        case 3 => Native
+        case n => in.decodeError(s"Unknown platform id for $n")
       }
     }
   }
 }
 
-@JsonCodec final case class JvmBuildTarget(
+final case class JvmBuildTarget(
     javaHome: Option[Uri],
     javaVersion: Option[String]
 )
 
-@JsonCodec final case class ScalaBuildTarget(
+object JvmBuildTarget {
+  implicit val codec: JsonValueCodec[JvmBuildTarget] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class ScalaBuildTarget(
     scalaOrganization: String,
     scalaVersion: String,
     scalaBinaryVersion: String,
@@ -627,27 +932,46 @@ object ScalaPlatform {
     jvmBuildTarget: Option[JvmBuildTarget]
 )
 
-@JsonCodec final case class ScalaTestParams(
+object ScalaBuildTarget {
+  implicit val codec: JsonValueCodec[ScalaBuildTarget] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class ScalaTestParams(
     testClasses: Option[List[ScalaTestClassesItem]],
-    jvmOptions: Option[List[String]],
+    jvmOptions: Option[List[String]]
 )
+
+object ScalaTestParams {
+  implicit val codec: JsonValueCodec[ScalaTestParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
 object TestParamsDataKind {
   val ScalaTest = "scala-test"
 }
 
 // Request: 'buildTarget/scalacOptions', C -> S
-@JsonCodec final case class ScalacOptionsParams(
+final case class ScalacOptionsParams(
     targets: List[BuildTargetIdentifier]
 )
 
+object ScalacOptionsParams {
+  implicit val codec: JsonValueCodec[ScalacOptionsParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
-@JsonCodec final case class JvmTestEnvironmentParams(
+final case class JvmTestEnvironmentParams(
     targets: List[BuildTargetIdentifier],
     originId: Option[String]
 )
 
-@JsonCodec final case class JvmEnvironmentItem(
+object JvmTestEnvironmentParams {
+  implicit val codec: JsonValueCodec[JvmTestEnvironmentParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class JvmEnvironmentItem(
     target: BuildTargetIdentifier,
     classpath: List[String],
     jvmOptions: List[String],
@@ -655,77 +979,148 @@ object TestParamsDataKind {
     environmentVariables: Map[String, String]
 )
 
-@JsonCodec final case class JvmTestEnvironmentResult(
+object JvmEnvironmentItem {
+  implicit val codec: JsonValueCodec[JvmEnvironmentItem] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class JvmTestEnvironmentResult(
     items: List[JvmEnvironmentItem]
 )
 
-@JsonCodec final case class JvmRunEnvironmentParams(
-   targets: List[BuildTargetIdentifier],
-   originId: Option[String]
+object JvmTestEnvironmentResult {
+  implicit val codec: JsonValueCodec[JvmTestEnvironmentResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class JvmRunEnvironmentParams(
+    targets: List[BuildTargetIdentifier],
+    originId: Option[String]
 )
 
-@JsonCodec final case class JvmRunEnvironmentResult(
-   items: List[JvmEnvironmentItem]
+object JvmRunEnvironmentParams {
+  implicit val codec: JsonValueCodec[JvmRunEnvironmentParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class JvmRunEnvironmentResult(
+    items: List[JvmEnvironmentItem]
 )
 
-@JsonCodec final case class ScalacOptionsItem(
+object JvmRunEnvironmentResult {
+  implicit val codec: JsonValueCodec[JvmRunEnvironmentResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class ScalacOptionsItem(
     target: BuildTargetIdentifier,
     options: List[String],
     classpath: List[Uri],
-    classDirectory: Uri,
+    classDirectory: Uri
 )
 
-@JsonCodec final case class ScalacOptionsResult(
+object ScalacOptionsItem {
+  implicit val codec: JsonValueCodec[ScalacOptionsItem] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class ScalacOptionsResult(
     items: List[ScalacOptionsItem]
 )
 
+object ScalacOptionsResult {
+  implicit val codec: JsonValueCodec[ScalacOptionsResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
 // Request: 'buildTarget/scalaTestClasses', C -> S
-@JsonCodec final case class ScalaTestClassesParams(
+final case class ScalaTestClassesParams(
     targets: List[BuildTargetIdentifier],
-    originId: Option[String],
+    originId: Option[String]
 )
 
-@JsonCodec final case class ScalaTestClassesItem(
+object ScalaTestClassesParams {
+  implicit val codec: JsonValueCodec[ScalaTestClassesParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class ScalaTestClassesItem(
     target: BuildTargetIdentifier,
     // Fully qualified names of test classes
     classes: List[String]
 )
 
-@JsonCodec final case class ScalaTestClassesResult(
+object ScalaTestClassesItem {
+  implicit val codec: JsonValueCodec[ScalaTestClassesItem] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class ScalaTestClassesResult(
     items: List[ScalaTestClassesItem]
 )
 
+object ScalaTestClassesResult {
+  implicit val codec: JsonValueCodec[ScalaTestClassesResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
 // Request: 'buildTarget/scalaMainClasses', C -> S
-@JsonCodec final case class ScalaMainClassesParams(
+final case class ScalaMainClassesParams(
     targets: List[BuildTargetIdentifier],
-    originId: Option[String],
+    originId: Option[String]
 )
 
-@JsonCodec final case class ScalaMainClass(
+object ScalaMainClassesParams {
+  implicit val codec: JsonValueCodec[ScalaMainClassesParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class ScalaMainClass(
     `class`: String,
     arguments: List[String],
     jvmOptions: List[String],
     environmentVariables: List[String]
 )
 
-@JsonCodec final case class ScalaMainClassesItem(
+object ScalaMainClass {
+  implicit val codec: JsonValueCodec[ScalaMainClass] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class ScalaMainClassesItem(
     target: BuildTargetIdentifier,
     // Fully qualified names of test classes
     classes: List[ScalaMainClass]
 )
 
-@JsonCodec final case class ScalaMainClassesResult(
+object ScalaMainClassesItem {
+  implicit val codec: JsonValueCodec[ScalaMainClassesItem] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class ScalaMainClassesResult(
     items: List[ScalaMainClassesItem]
 )
 
-@JsonCodec final case class SbtBuildTarget(
+object ScalaMainClassesResult {
+  implicit val codec: JsonValueCodec[ScalaMainClassesResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class SbtBuildTarget(
     sbtVersion: String,
     autoImports: List[String],
     scalaBuildTarget: ScalaBuildTarget,
     parent: Option[BuildTargetIdentifier],
-    children: List[BuildTargetIdentifier],
+    children: List[BuildTargetIdentifier]
 )
-@JsonCodec final case class BspConnectionDetails(
+
+object SbtBuildTarget {
+  implicit val codec: JsonValueCodec[SbtBuildTarget] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class BspConnectionDetails(
     name: String,
     argv: List[String],
     version: String,
@@ -733,11 +1128,21 @@ object TestParamsDataKind {
     languages: List[String]
 )
 
-@JsonCodec final case class DebugSessionParams(
+object BspConnectionDetails {
+  implicit val codec: JsonValueCodec[BspConnectionDetails] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class DebugSessionParams(
     targets: List[BuildTargetIdentifier],
     dataKind: String,
-    data: Json
+    data: RawJson
 )
+
+object DebugSessionParams {
+  implicit val codec: JsonValueCodec[DebugSessionParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
 
 object DebugSessionParamsDataKind {
   val ScalaMainClass = "scala-main-class"
@@ -745,35 +1150,65 @@ object DebugSessionParamsDataKind {
   val ScalaAttachRemote = "scala-attach-remote"
 }
 
-@JsonCodec final case class DebugSessionAddress(uri: String)
+final case class DebugSessionAddress(uri: String)
 
-@JsonCodec final case class JavacOptionsParams(
+object DebugSessionAddress {
+  implicit val codec: JsonValueCodec[DebugSessionAddress] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class JavacOptionsParams(
     targets: List[BuildTargetIdentifier]
 )
 
-@JsonCodec final case class JavacOptionsItem(
+object JavacOptionsParams {
+  implicit val codec: JsonValueCodec[JavacOptionsParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class JavacOptionsItem(
     target: BuildTargetIdentifier,
     options: List[String],
     classpath: List[Uri],
     classDirectory: Uri
 )
 
-@JsonCodec final case class JavacOptionsResult(
+object JavacOptionsItem {
+  implicit val codec: JsonValueCodec[JavacOptionsItem] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class JavacOptionsResult(
     items: List[JavacOptionsItem]
 )
 
-@JsonCodec final case class CppBuildTarget(
+object JavacOptionsResult {
+  implicit val codec: JsonValueCodec[JavacOptionsResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class CppBuildTarget(
     version: Option[String],
     compiler: Option[String],
     cCompiler: Option[Uri],
     cppCompiler: Option[Uri],
 )
 
-@JsonCodec final case class CppOptionsParams(
+object CppBuildTarget {
+  implicit val codec: JsonValueCodec[CppBuildTarget] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class CppOptionsParams(
     targets: List[BuildTargetIdentifier]
 )
 
-@JsonCodec final case class CppOptionsItem(
+object CppOptionsParams {
+  implicit val codec: JsonValueCodec[CppOptionsParams] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class CppOptionsItem(
     target: BuildTargetIdentifier,
     copts: List[String],
     defines: List[String],
@@ -781,6 +1216,16 @@ object DebugSessionParamsDataKind {
     linkshared: Boolean,
 )
 
-@JsonCodec final case class CppOptionsResult(
+object CppOptionsItem {
+  implicit val codec: JsonValueCodec[CppOptionsItem] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}
+
+final case class CppOptionsResult(
     items: List[CppOptionsItem]
 )
+
+object CppOptionsResult {
+  implicit val codec: JsonValueCodec[CppOptionsResult] =
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+}

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -41,7 +41,7 @@ final case class TextDocumentIdentifier(
 
 object TextDocumentIdentifier {
   implicit val codec: JsonValueCodec[TextDocumentIdentifier] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class BuildTargetIdentifier(
@@ -50,7 +50,7 @@ final case class BuildTargetIdentifier(
 
 object BuildTargetIdentifier {
   implicit val codec: JsonValueCodec[BuildTargetIdentifier] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class BuildTargetCapabilities(
@@ -62,7 +62,7 @@ final case class BuildTargetCapabilities(
 
 object BuildTargetCapabilities {
   implicit val codec: JsonValueCodec[BuildTargetCapabilities] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 object BuildTargetTag {
@@ -89,7 +89,7 @@ final case class BuildTarget(
 
 object BuildTarget {
   implicit val codec: JsonValueCodec[BuildTarget] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 object BuildTargetDataKind {
@@ -103,7 +103,7 @@ final case class BuildClientCapabilities(
 
 object BuildClientCapabilities {
   implicit val codec: JsonValueCodec[BuildClientCapabilities] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 // Notification: 'build/initialized', C -> S
@@ -111,7 +111,7 @@ final case class InitializedBuildParams()
 
 object InitializedBuildParams {
   implicit val codec: JsonValueCodec[InitializedBuildParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 // Request: 'build/initialize', C -> S
@@ -126,28 +126,28 @@ final case class InitializeBuildParams(
 
 object InitializeBuildParams {
   implicit val codec: JsonValueCodec[InitializeBuildParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class Reload()
 
 object Reload {
   implicit val codec: JsonValueCodec[Reload] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class Shutdown()
 
 object Shutdown {
   implicit val codec: JsonValueCodec[Shutdown] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class Exit()
 
 object Exit {
   implicit val codec: JsonValueCodec[Exit] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class CompileProvider(
@@ -156,7 +156,7 @@ final case class CompileProvider(
 
 object CompileProvider {
   implicit val codec: JsonValueCodec[CompileProvider] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class TestProvider(
@@ -165,7 +165,7 @@ final case class TestProvider(
 
 object TestProvider {
   implicit val codec: JsonValueCodec[TestProvider] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class RunProvider(
@@ -174,7 +174,7 @@ final case class RunProvider(
 
 object RunProvider {
   implicit val codec: JsonValueCodec[RunProvider] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class DebugProvider(
@@ -183,7 +183,7 @@ final case class DebugProvider(
 
 object DebugProvider {
   implicit val codec: JsonValueCodec[DebugProvider] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class BuildServerCapabilities(
@@ -203,7 +203,7 @@ final case class BuildServerCapabilities(
 
 object BuildServerCapabilities {
   implicit val codec: JsonValueCodec[BuildServerCapabilities] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class InitializeBuildResult(
@@ -216,7 +216,7 @@ final case class InitializeBuildResult(
 
 object InitializeBuildResult {
   implicit val codec: JsonValueCodec[InitializeBuildResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 sealed abstract class MessageType(val id: Int)
@@ -248,7 +248,7 @@ final case class TaskId(
 
 object TaskId {
   implicit val codec: JsonValueCodec[TaskId] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class ShowMessageParams(
@@ -260,7 +260,7 @@ final case class ShowMessageParams(
 
 object ShowMessageParams {
   implicit val codec: JsonValueCodec[ShowMessageParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class LogMessageParams(
@@ -272,7 +272,7 @@ final case class LogMessageParams(
 
 object LogMessageParams {
   implicit val codec: JsonValueCodec[LogMessageParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class Position(
@@ -282,7 +282,7 @@ final case class Position(
 
 object Position {
   implicit val codec: JsonValueCodec[Position] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class Range(
@@ -292,7 +292,7 @@ final case class Range(
 
 object Range {
   implicit val codec: JsonValueCodec[Range] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 case class Location(
@@ -301,7 +301,7 @@ case class Location(
 )
 object Location {
   implicit val codec: JsonValueCodec[Location] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 sealed abstract class DiagnosticSeverity(val id: Int)
@@ -334,7 +334,7 @@ final case class DiagnosticRelatedInformation(
 
 object DiagnosticRelatedInformation {
   implicit val codec: JsonValueCodec[DiagnosticRelatedInformation] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class Diagnostic(
@@ -348,7 +348,7 @@ final case class Diagnostic(
 
 object Diagnostic {
   implicit val codec: JsonValueCodec[Diagnostic] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class PublishDiagnosticsParams(
@@ -361,14 +361,14 @@ final case class PublishDiagnosticsParams(
 
 object PublishDiagnosticsParams {
   implicit val codec: JsonValueCodec[PublishDiagnosticsParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class WorkspaceBuildTargetsRequest()
 
 object WorkspaceBuildTargetsRequest {
   implicit val codec: JsonValueCodec[WorkspaceBuildTargetsRequest] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 // Request: 'workspace/buildTargets'
@@ -378,7 +378,7 @@ final case class WorkspaceBuildTargetsResult(
 
 object WorkspaceBuildTargetsResult {
   implicit val codec: JsonValueCodec[WorkspaceBuildTargetsResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 sealed abstract class BuildTargetEventKind(val id: Int)
@@ -411,7 +411,7 @@ final case class BuildTargetEvent(
 
 object BuildTargetEvent {
   implicit val codec: JsonValueCodec[BuildTargetEvent] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 // Notification: 'buildTarget/didChange', S -> C
@@ -421,7 +421,7 @@ final case class DidChangeBuildTarget(
 
 object DidChangeBuildTarget {
   implicit val codec: JsonValueCodec[DidChangeBuildTarget] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 // Request: 'buildTarget/sources', C -> S
@@ -431,7 +431,7 @@ final case class SourcesParams(
 
 object SourcesParams {
   implicit val codec: JsonValueCodec[SourcesParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class SourcesResult(
@@ -440,7 +440,7 @@ final case class SourcesResult(
 
 object SourcesResult {
   implicit val codec: JsonValueCodec[SourcesResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class SourcesItem(
@@ -451,7 +451,7 @@ final case class SourcesItem(
 
 object SourcesItem {
   implicit val codec: JsonValueCodec[SourcesItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class SourceItem(
@@ -462,7 +462,7 @@ final case class SourceItem(
 
 object SourceItem {
   implicit val codec: JsonValueCodec[SourceItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 sealed abstract class SourceItemKind(val id: Int)
@@ -491,7 +491,7 @@ final case class InverseSourcesParams(
 
 object InverseSourcesParams {
   implicit val codec: JsonValueCodec[InverseSourcesParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class InverseSourcesResult(
@@ -500,7 +500,7 @@ final case class InverseSourcesResult(
 
 object InverseSourcesResult {
   implicit val codec: JsonValueCodec[InverseSourcesResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 // Request: 'buildTarget/dependencySources', C -> S
@@ -510,7 +510,7 @@ final case class DependencySourcesParams(
 
 object DependencySourcesParams {
   implicit val codec: JsonValueCodec[DependencySourcesParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class DependencySourcesItem(
@@ -520,7 +520,7 @@ final case class DependencySourcesItem(
 
 object DependencySourcesItem {
   implicit val codec: JsonValueCodec[DependencySourcesItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class DependencySourcesResult(
@@ -529,7 +529,7 @@ final case class DependencySourcesResult(
 
 object DependencySourcesResult {
   implicit val codec: JsonValueCodec[DependencySourcesResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class DependencyModulesParams(
@@ -538,7 +538,7 @@ final case class DependencyModulesParams(
 
 object DependencyModulesParams {
   implicit val codec: JsonValueCodec[DependencyModulesParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class DependencyModule(
@@ -550,7 +550,7 @@ final case class DependencyModule(
 
 object DependencyModule {
   implicit val codec: JsonValueCodec[DependencyModule] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 object DependencyModuleDataKind {
@@ -564,7 +564,7 @@ final case class DependencyModulesItem(
 
 object DependencyModulesItem {
   implicit val codec: JsonValueCodec[DependencyModulesItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class DependencyModulesResult(
@@ -573,7 +573,7 @@ final case class DependencyModulesResult(
 
 object DependencyModulesResult {
   implicit val codec: JsonValueCodec[DependencyModulesResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class MavenDependencyModuleArtifact(
@@ -583,7 +583,7 @@ final case class MavenDependencyModuleArtifact(
 
 object MavenDependencyModuleArtifact {
   implicit val codec: JsonValueCodec[MavenDependencyModuleArtifact] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class MavenDependencyModule(
@@ -596,7 +596,7 @@ final case class MavenDependencyModule(
 
 object MavenDependencyModule {
   implicit val codec: JsonValueCodec[MavenDependencyModule] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 // Request: 'buildTarget/resources', C -> S
@@ -606,7 +606,7 @@ final case class ResourcesParams(
 
 object ResourcesParams {
   implicit val codec: JsonValueCodec[ResourcesParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class ResourcesResult(
@@ -615,7 +615,7 @@ final case class ResourcesResult(
 
 object ResourcesResult {
   implicit val codec: JsonValueCodec[ResourcesResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class ResourcesItem(
@@ -625,7 +625,7 @@ final case class ResourcesItem(
 
 object ResourcesItem {
   implicit val codec: JsonValueCodec[ResourcesItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 // Request: 'buildTarget/compile', C -> S
@@ -637,7 +637,7 @@ final case class CompileParams(
 
 object CompileParams {
   implicit val codec: JsonValueCodec[CompileParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class CompileResult(
@@ -649,7 +649,7 @@ final case class CompileResult(
 
 object CompileResult {
   implicit val codec: JsonValueCodec[CompileResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class CompileReport(
@@ -662,7 +662,7 @@ final case class CompileReport(
 
 object CompileReport {
   implicit val codec: JsonValueCodec[CompileReport] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class CompileTask(
@@ -671,7 +671,7 @@ final case class CompileTask(
 
 object CompileTask {
   implicit val codec: JsonValueCodec[CompileTask] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class TestParams(
@@ -684,7 +684,7 @@ final case class TestParams(
 
 object TestParams {
   implicit val codec: JsonValueCodec[TestParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class TestResult(
@@ -696,7 +696,7 @@ final case class TestResult(
 
 object TestResult {
   implicit val codec: JsonValueCodec[TestResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class TestReport(
@@ -712,7 +712,7 @@ final case class TestReport(
 
 object TestReport {
   implicit val codec: JsonValueCodec[TestReport] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class TestTask(
@@ -721,7 +721,7 @@ final case class TestTask(
 
 object TestTask {
   implicit val codec: JsonValueCodec[TestTask] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class TestStart(
@@ -731,7 +731,7 @@ final case class TestStart(
 
 object TestStart {
   implicit val codec: JsonValueCodec[TestStart] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class TestFinish(
@@ -745,7 +745,7 @@ final case class TestFinish(
 
 object TestFinish {
   implicit val codec: JsonValueCodec[TestFinish] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 sealed abstract class TestStatus(val code: Int)
@@ -783,7 +783,7 @@ final case class RunParams(
 
 object RunParams {
   implicit val codec: JsonValueCodec[RunParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 object RunParamsDataKind {
@@ -818,7 +818,7 @@ final case class RunResult(
 
 object RunResult {
   implicit val codec: JsonValueCodec[RunResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class CleanCacheParams(
@@ -827,7 +827,7 @@ final case class CleanCacheParams(
 
 object CleanCacheParams {
   implicit val codec: JsonValueCodec[CleanCacheParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class CleanCacheResult(
@@ -837,7 +837,7 @@ final case class CleanCacheResult(
 
 object CleanCacheResult {
   implicit val codec: JsonValueCodec[CleanCacheResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class TaskStartParams(
@@ -850,7 +850,7 @@ final case class TaskStartParams(
 
 object TaskStartParams {
   implicit val codec: JsonValueCodec[TaskStartParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class TaskProgressParams(
@@ -866,7 +866,7 @@ final case class TaskProgressParams(
 
 object TaskProgressParams {
   implicit val codec: JsonValueCodec[TaskProgressParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class TaskFinishParams(
@@ -880,7 +880,7 @@ final case class TaskFinishParams(
 
 object TaskFinishParams {
   implicit val codec: JsonValueCodec[TaskFinishParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 object TaskDataKind {
@@ -920,7 +920,7 @@ final case class JvmBuildTarget(
 
 object JvmBuildTarget {
   implicit val codec: JsonValueCodec[JvmBuildTarget] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class ScalaBuildTarget(
@@ -934,7 +934,7 @@ final case class ScalaBuildTarget(
 
 object ScalaBuildTarget {
   implicit val codec: JsonValueCodec[ScalaBuildTarget] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class ScalaTestParams(
@@ -944,7 +944,7 @@ final case class ScalaTestParams(
 
 object ScalaTestParams {
   implicit val codec: JsonValueCodec[ScalaTestParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 object TestParamsDataKind {
@@ -958,7 +958,7 @@ final case class ScalacOptionsParams(
 
 object ScalacOptionsParams {
   implicit val codec: JsonValueCodec[ScalacOptionsParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class JvmTestEnvironmentParams(
@@ -968,7 +968,7 @@ final case class JvmTestEnvironmentParams(
 
 object JvmTestEnvironmentParams {
   implicit val codec: JsonValueCodec[JvmTestEnvironmentParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class JvmEnvironmentItem(
@@ -981,7 +981,7 @@ final case class JvmEnvironmentItem(
 
 object JvmEnvironmentItem {
   implicit val codec: JsonValueCodec[JvmEnvironmentItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class JvmTestEnvironmentResult(
@@ -990,7 +990,7 @@ final case class JvmTestEnvironmentResult(
 
 object JvmTestEnvironmentResult {
   implicit val codec: JsonValueCodec[JvmTestEnvironmentResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class JvmRunEnvironmentParams(
@@ -1000,7 +1000,7 @@ final case class JvmRunEnvironmentParams(
 
 object JvmRunEnvironmentParams {
   implicit val codec: JsonValueCodec[JvmRunEnvironmentParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class JvmRunEnvironmentResult(
@@ -1009,7 +1009,7 @@ final case class JvmRunEnvironmentResult(
 
 object JvmRunEnvironmentResult {
   implicit val codec: JsonValueCodec[JvmRunEnvironmentResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class ScalacOptionsItem(
@@ -1021,7 +1021,7 @@ final case class ScalacOptionsItem(
 
 object ScalacOptionsItem {
   implicit val codec: JsonValueCodec[ScalacOptionsItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class ScalacOptionsResult(
@@ -1030,7 +1030,7 @@ final case class ScalacOptionsResult(
 
 object ScalacOptionsResult {
   implicit val codec: JsonValueCodec[ScalacOptionsResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 // Request: 'buildTarget/scalaTestClasses', C -> S
@@ -1041,7 +1041,7 @@ final case class ScalaTestClassesParams(
 
 object ScalaTestClassesParams {
   implicit val codec: JsonValueCodec[ScalaTestClassesParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class ScalaTestClassesItem(
@@ -1052,7 +1052,7 @@ final case class ScalaTestClassesItem(
 
 object ScalaTestClassesItem {
   implicit val codec: JsonValueCodec[ScalaTestClassesItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class ScalaTestClassesResult(
@@ -1061,7 +1061,7 @@ final case class ScalaTestClassesResult(
 
 object ScalaTestClassesResult {
   implicit val codec: JsonValueCodec[ScalaTestClassesResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 // Request: 'buildTarget/scalaMainClasses', C -> S
@@ -1072,7 +1072,7 @@ final case class ScalaMainClassesParams(
 
 object ScalaMainClassesParams {
   implicit val codec: JsonValueCodec[ScalaMainClassesParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class ScalaMainClass(
@@ -1084,7 +1084,7 @@ final case class ScalaMainClass(
 
 object ScalaMainClass {
   implicit val codec: JsonValueCodec[ScalaMainClass] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class ScalaMainClassesItem(
@@ -1095,7 +1095,7 @@ final case class ScalaMainClassesItem(
 
 object ScalaMainClassesItem {
   implicit val codec: JsonValueCodec[ScalaMainClassesItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class ScalaMainClassesResult(
@@ -1104,7 +1104,7 @@ final case class ScalaMainClassesResult(
 
 object ScalaMainClassesResult {
   implicit val codec: JsonValueCodec[ScalaMainClassesResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class SbtBuildTarget(
@@ -1117,7 +1117,7 @@ final case class SbtBuildTarget(
 
 object SbtBuildTarget {
   implicit val codec: JsonValueCodec[SbtBuildTarget] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class BspConnectionDetails(
@@ -1130,7 +1130,7 @@ final case class BspConnectionDetails(
 
 object BspConnectionDetails {
   implicit val codec: JsonValueCodec[BspConnectionDetails] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class DebugSessionParams(
@@ -1141,7 +1141,7 @@ final case class DebugSessionParams(
 
 object DebugSessionParams {
   implicit val codec: JsonValueCodec[DebugSessionParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 object DebugSessionParamsDataKind {
@@ -1154,7 +1154,7 @@ final case class DebugSessionAddress(uri: String)
 
 object DebugSessionAddress {
   implicit val codec: JsonValueCodec[DebugSessionAddress] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class JavacOptionsParams(
@@ -1163,7 +1163,7 @@ final case class JavacOptionsParams(
 
 object JavacOptionsParams {
   implicit val codec: JsonValueCodec[JavacOptionsParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class JavacOptionsItem(
@@ -1175,7 +1175,7 @@ final case class JavacOptionsItem(
 
 object JavacOptionsItem {
   implicit val codec: JsonValueCodec[JavacOptionsItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class JavacOptionsResult(
@@ -1184,7 +1184,7 @@ final case class JavacOptionsResult(
 
 object JavacOptionsResult {
   implicit val codec: JsonValueCodec[JavacOptionsResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class CppBuildTarget(
@@ -1196,7 +1196,7 @@ final case class CppBuildTarget(
 
 object CppBuildTarget {
   implicit val codec: JsonValueCodec[CppBuildTarget] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class CppOptionsParams(
@@ -1205,7 +1205,7 @@ final case class CppOptionsParams(
 
 object CppOptionsParams {
   implicit val codec: JsonValueCodec[CppOptionsParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class CppOptionsItem(
@@ -1218,7 +1218,7 @@ final case class CppOptionsItem(
 
 object CppOptionsItem {
   implicit val codec: JsonValueCodec[CppOptionsItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }
 
 final case class CppOptionsResult(
@@ -1227,5 +1227,5 @@ final case class CppOptionsResult(
 
 object CppOptionsResult {
   implicit val codec: JsonValueCodec[CppOptionsResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(true))
+    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
 }

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -57,7 +57,7 @@ final case class BuildTargetCapabilities(
     canCompile: Boolean,
     canTest: Boolean,
     canRun: Boolean,
-    canDebug: Boolean = false, // backward compatible default
+    canDebug: Boolean = false // backward compatible default
 )
 
 object BuildTargetCapabilities {
@@ -129,18 +129,40 @@ object InitializeBuildParams {
     JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
+object NullAllowingCodecWrapper {
+
+  def apply[A](codec: JsonValueCodec[A]): JsonValueCodec[A] =
+    new JsonValueCodec[A] {
+      override def decodeValue(in: JsonReader, default: A): A =
+        if (in.isNextToken('n')) {
+          in.readNullOrError[String]("x", "expected value or null")
+          nullValue
+        } else {
+          in.rollbackToken()
+          codec.decodeValue(in, default)
+        }
+
+      override def encodeValue(x: A, out: JsonWriter): Unit =
+        if (x == null) out.writeNull()
+        else codec.encodeValue(x, out)
+
+      override val nullValue: A = null.asInstanceOf[A]
+    }
+
+}
+
 final case class Reload()
 
 object Reload {
   implicit val codec: JsonValueCodec[Reload] =
-    JsonCodecMaker.makeWithRequiredCollectionFields
+    NullAllowingCodecWrapper(JsonCodecMaker.make)
 }
 
 final case class Shutdown()
 
 object Shutdown {
   implicit val codec: JsonValueCodec[Shutdown] =
-    JsonCodecMaker.makeWithRequiredCollectionFields
+    NullAllowingCodecWrapper(JsonCodecMaker.make)
 }
 
 final case class Exit()
@@ -178,7 +200,7 @@ object RunProvider {
 }
 
 final case class DebugProvider(
-  languageIds: List[String]
+    languageIds: List[String]
 )
 
 object DebugProvider {
@@ -198,7 +220,7 @@ final case class BuildServerCapabilities(
     buildTargetChangedProvider: Option[Boolean],
     jvmTestEnvironmentProvider: Option[Boolean],
     jvmRunEnvironmentProvider: Option[Boolean],
-    canReload: Option[Boolean],
+    canReload: Option[Boolean]
 )
 
 object BuildServerCapabilities {
@@ -368,7 +390,7 @@ final case class WorkspaceBuildTargetsRequest()
 
 object WorkspaceBuildTargetsRequest {
   implicit val codec: JsonValueCodec[WorkspaceBuildTargetsRequest] =
-    JsonCodecMaker.makeWithRequiredCollectionFields
+    NullAllowingCodecWrapper(JsonCodecMaker.make)
 }
 
 // Request: 'workspace/buildTargets'
@@ -542,10 +564,10 @@ object DependencyModulesParams {
 }
 
 final case class DependencyModule(
-  name: String,
-  version: String,
-  dataKind: Option[String],
-  data: Option[RawJson]
+    name: String,
+    version: String,
+    dataKind: Option[String],
+    data: Option[RawJson]
 )
 
 object DependencyModule {
@@ -558,8 +580,8 @@ object DependencyModuleDataKind {
 }
 
 final case class DependencyModulesItem(
-  target: BuildTargetIdentifier,
-  modules: List[DependencyModule]
+    target: BuildTargetIdentifier,
+    modules: List[DependencyModule]
 )
 
 object DependencyModulesItem {
@@ -568,7 +590,7 @@ object DependencyModulesItem {
 }
 
 final case class DependencyModulesResult(
-  items: List[DependencyModulesItem]
+    items: List[DependencyModulesItem]
 )
 
 object DependencyModulesResult {
@@ -577,8 +599,8 @@ object DependencyModulesResult {
 }
 
 final case class MavenDependencyModuleArtifact(
-  uri: String,
-  classifier: Option[String],
+    uri: String,
+    classifier: Option[String]
 )
 
 object MavenDependencyModuleArtifact {
@@ -587,11 +609,11 @@ object MavenDependencyModuleArtifact {
 }
 
 final case class MavenDependencyModule(
-  organization: String,
-  name: String,
-  version: String,
-  artifacts: List[MavenDependencyModuleArtifact],
-  scope: Option[String]
+    organization: String,
+    name: String,
+    version: String,
+    artifacts: List[MavenDependencyModuleArtifact],
+    scope: Option[String]
 )
 
 object MavenDependencyModule {
@@ -1191,7 +1213,7 @@ final case class CppBuildTarget(
     version: Option[String],
     compiler: Option[String],
     cCompiler: Option[Uri],
-    cppCompiler: Option[Uri],
+    cppCompiler: Option[Uri]
 )
 
 object CppBuildTarget {
@@ -1213,7 +1235,7 @@ final case class CppOptionsItem(
     copts: List[String],
     defines: List[String],
     linkopts: List[String],
-    linkshared: Boolean,
+    linkshared: Boolean
 )
 
 object CppOptionsItem {

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -41,7 +41,7 @@ final case class TextDocumentIdentifier(
 
 object TextDocumentIdentifier {
   implicit val codec: JsonValueCodec[TextDocumentIdentifier] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class BuildTargetIdentifier(
@@ -50,7 +50,7 @@ final case class BuildTargetIdentifier(
 
 object BuildTargetIdentifier {
   implicit val codec: JsonValueCodec[BuildTargetIdentifier] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class BuildTargetCapabilities(
@@ -62,7 +62,7 @@ final case class BuildTargetCapabilities(
 
 object BuildTargetCapabilities {
   implicit val codec: JsonValueCodec[BuildTargetCapabilities] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 object BuildTargetTag {
@@ -89,7 +89,7 @@ final case class BuildTarget(
 
 object BuildTarget {
   implicit val codec: JsonValueCodec[BuildTarget] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 object BuildTargetDataKind {
@@ -103,7 +103,7 @@ final case class BuildClientCapabilities(
 
 object BuildClientCapabilities {
   implicit val codec: JsonValueCodec[BuildClientCapabilities] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 // Notification: 'build/initialized', C -> S
@@ -111,7 +111,7 @@ final case class InitializedBuildParams()
 
 object InitializedBuildParams {
   implicit val codec: JsonValueCodec[InitializedBuildParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 // Request: 'build/initialize', C -> S
@@ -126,28 +126,28 @@ final case class InitializeBuildParams(
 
 object InitializeBuildParams {
   implicit val codec: JsonValueCodec[InitializeBuildParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class Reload()
 
 object Reload {
   implicit val codec: JsonValueCodec[Reload] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class Shutdown()
 
 object Shutdown {
   implicit val codec: JsonValueCodec[Shutdown] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class Exit()
 
 object Exit {
   implicit val codec: JsonValueCodec[Exit] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class CompileProvider(
@@ -156,7 +156,7 @@ final case class CompileProvider(
 
 object CompileProvider {
   implicit val codec: JsonValueCodec[CompileProvider] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class TestProvider(
@@ -165,7 +165,7 @@ final case class TestProvider(
 
 object TestProvider {
   implicit val codec: JsonValueCodec[TestProvider] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class RunProvider(
@@ -174,7 +174,7 @@ final case class RunProvider(
 
 object RunProvider {
   implicit val codec: JsonValueCodec[RunProvider] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class DebugProvider(
@@ -183,7 +183,7 @@ final case class DebugProvider(
 
 object DebugProvider {
   implicit val codec: JsonValueCodec[DebugProvider] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class BuildServerCapabilities(
@@ -203,7 +203,7 @@ final case class BuildServerCapabilities(
 
 object BuildServerCapabilities {
   implicit val codec: JsonValueCodec[BuildServerCapabilities] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class InitializeBuildResult(
@@ -216,7 +216,7 @@ final case class InitializeBuildResult(
 
 object InitializeBuildResult {
   implicit val codec: JsonValueCodec[InitializeBuildResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 sealed abstract class MessageType(val id: Int)
@@ -248,7 +248,7 @@ final case class TaskId(
 
 object TaskId {
   implicit val codec: JsonValueCodec[TaskId] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class ShowMessageParams(
@@ -260,7 +260,7 @@ final case class ShowMessageParams(
 
 object ShowMessageParams {
   implicit val codec: JsonValueCodec[ShowMessageParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class LogMessageParams(
@@ -272,7 +272,7 @@ final case class LogMessageParams(
 
 object LogMessageParams {
   implicit val codec: JsonValueCodec[LogMessageParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class Position(
@@ -282,7 +282,7 @@ final case class Position(
 
 object Position {
   implicit val codec: JsonValueCodec[Position] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class Range(
@@ -292,7 +292,7 @@ final case class Range(
 
 object Range {
   implicit val codec: JsonValueCodec[Range] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 case class Location(
@@ -301,7 +301,7 @@ case class Location(
 )
 object Location {
   implicit val codec: JsonValueCodec[Location] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 sealed abstract class DiagnosticSeverity(val id: Int)
@@ -334,7 +334,7 @@ final case class DiagnosticRelatedInformation(
 
 object DiagnosticRelatedInformation {
   implicit val codec: JsonValueCodec[DiagnosticRelatedInformation] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class Diagnostic(
@@ -348,7 +348,7 @@ final case class Diagnostic(
 
 object Diagnostic {
   implicit val codec: JsonValueCodec[Diagnostic] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class PublishDiagnosticsParams(
@@ -361,14 +361,14 @@ final case class PublishDiagnosticsParams(
 
 object PublishDiagnosticsParams {
   implicit val codec: JsonValueCodec[PublishDiagnosticsParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class WorkspaceBuildTargetsRequest()
 
 object WorkspaceBuildTargetsRequest {
   implicit val codec: JsonValueCodec[WorkspaceBuildTargetsRequest] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 // Request: 'workspace/buildTargets'
@@ -378,7 +378,7 @@ final case class WorkspaceBuildTargetsResult(
 
 object WorkspaceBuildTargetsResult {
   implicit val codec: JsonValueCodec[WorkspaceBuildTargetsResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 sealed abstract class BuildTargetEventKind(val id: Int)
@@ -411,7 +411,7 @@ final case class BuildTargetEvent(
 
 object BuildTargetEvent {
   implicit val codec: JsonValueCodec[BuildTargetEvent] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 // Notification: 'buildTarget/didChange', S -> C
@@ -421,7 +421,7 @@ final case class DidChangeBuildTarget(
 
 object DidChangeBuildTarget {
   implicit val codec: JsonValueCodec[DidChangeBuildTarget] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 // Request: 'buildTarget/sources', C -> S
@@ -431,7 +431,7 @@ final case class SourcesParams(
 
 object SourcesParams {
   implicit val codec: JsonValueCodec[SourcesParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class SourcesResult(
@@ -440,7 +440,7 @@ final case class SourcesResult(
 
 object SourcesResult {
   implicit val codec: JsonValueCodec[SourcesResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class SourcesItem(
@@ -451,7 +451,7 @@ final case class SourcesItem(
 
 object SourcesItem {
   implicit val codec: JsonValueCodec[SourcesItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class SourceItem(
@@ -462,7 +462,7 @@ final case class SourceItem(
 
 object SourceItem {
   implicit val codec: JsonValueCodec[SourceItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 sealed abstract class SourceItemKind(val id: Int)
@@ -491,7 +491,7 @@ final case class InverseSourcesParams(
 
 object InverseSourcesParams {
   implicit val codec: JsonValueCodec[InverseSourcesParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class InverseSourcesResult(
@@ -500,7 +500,7 @@ final case class InverseSourcesResult(
 
 object InverseSourcesResult {
   implicit val codec: JsonValueCodec[InverseSourcesResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 // Request: 'buildTarget/dependencySources', C -> S
@@ -510,7 +510,7 @@ final case class DependencySourcesParams(
 
 object DependencySourcesParams {
   implicit val codec: JsonValueCodec[DependencySourcesParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class DependencySourcesItem(
@@ -520,7 +520,7 @@ final case class DependencySourcesItem(
 
 object DependencySourcesItem {
   implicit val codec: JsonValueCodec[DependencySourcesItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class DependencySourcesResult(
@@ -529,7 +529,7 @@ final case class DependencySourcesResult(
 
 object DependencySourcesResult {
   implicit val codec: JsonValueCodec[DependencySourcesResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class DependencyModulesParams(
@@ -538,7 +538,7 @@ final case class DependencyModulesParams(
 
 object DependencyModulesParams {
   implicit val codec: JsonValueCodec[DependencyModulesParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class DependencyModule(
@@ -550,7 +550,7 @@ final case class DependencyModule(
 
 object DependencyModule {
   implicit val codec: JsonValueCodec[DependencyModule] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 object DependencyModuleDataKind {
@@ -564,7 +564,7 @@ final case class DependencyModulesItem(
 
 object DependencyModulesItem {
   implicit val codec: JsonValueCodec[DependencyModulesItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class DependencyModulesResult(
@@ -573,7 +573,7 @@ final case class DependencyModulesResult(
 
 object DependencyModulesResult {
   implicit val codec: JsonValueCodec[DependencyModulesResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class MavenDependencyModuleArtifact(
@@ -583,7 +583,7 @@ final case class MavenDependencyModuleArtifact(
 
 object MavenDependencyModuleArtifact {
   implicit val codec: JsonValueCodec[MavenDependencyModuleArtifact] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class MavenDependencyModule(
@@ -596,7 +596,7 @@ final case class MavenDependencyModule(
 
 object MavenDependencyModule {
   implicit val codec: JsonValueCodec[MavenDependencyModule] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 // Request: 'buildTarget/resources', C -> S
@@ -606,7 +606,7 @@ final case class ResourcesParams(
 
 object ResourcesParams {
   implicit val codec: JsonValueCodec[ResourcesParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class ResourcesResult(
@@ -615,7 +615,7 @@ final case class ResourcesResult(
 
 object ResourcesResult {
   implicit val codec: JsonValueCodec[ResourcesResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class ResourcesItem(
@@ -625,7 +625,7 @@ final case class ResourcesItem(
 
 object ResourcesItem {
   implicit val codec: JsonValueCodec[ResourcesItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 // Request: 'buildTarget/compile', C -> S
@@ -637,7 +637,7 @@ final case class CompileParams(
 
 object CompileParams {
   implicit val codec: JsonValueCodec[CompileParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class CompileResult(
@@ -649,7 +649,7 @@ final case class CompileResult(
 
 object CompileResult {
   implicit val codec: JsonValueCodec[CompileResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class CompileReport(
@@ -662,7 +662,7 @@ final case class CompileReport(
 
 object CompileReport {
   implicit val codec: JsonValueCodec[CompileReport] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class CompileTask(
@@ -671,7 +671,7 @@ final case class CompileTask(
 
 object CompileTask {
   implicit val codec: JsonValueCodec[CompileTask] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class TestParams(
@@ -684,7 +684,7 @@ final case class TestParams(
 
 object TestParams {
   implicit val codec: JsonValueCodec[TestParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class TestResult(
@@ -696,7 +696,7 @@ final case class TestResult(
 
 object TestResult {
   implicit val codec: JsonValueCodec[TestResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class TestReport(
@@ -712,7 +712,7 @@ final case class TestReport(
 
 object TestReport {
   implicit val codec: JsonValueCodec[TestReport] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class TestTask(
@@ -721,7 +721,7 @@ final case class TestTask(
 
 object TestTask {
   implicit val codec: JsonValueCodec[TestTask] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class TestStart(
@@ -731,7 +731,7 @@ final case class TestStart(
 
 object TestStart {
   implicit val codec: JsonValueCodec[TestStart] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class TestFinish(
@@ -745,7 +745,7 @@ final case class TestFinish(
 
 object TestFinish {
   implicit val codec: JsonValueCodec[TestFinish] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 sealed abstract class TestStatus(val code: Int)
@@ -783,7 +783,7 @@ final case class RunParams(
 
 object RunParams {
   implicit val codec: JsonValueCodec[RunParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 object RunParamsDataKind {
@@ -818,7 +818,7 @@ final case class RunResult(
 
 object RunResult {
   implicit val codec: JsonValueCodec[RunResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class CleanCacheParams(
@@ -827,7 +827,7 @@ final case class CleanCacheParams(
 
 object CleanCacheParams {
   implicit val codec: JsonValueCodec[CleanCacheParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class CleanCacheResult(
@@ -837,7 +837,7 @@ final case class CleanCacheResult(
 
 object CleanCacheResult {
   implicit val codec: JsonValueCodec[CleanCacheResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class TaskStartParams(
@@ -850,7 +850,7 @@ final case class TaskStartParams(
 
 object TaskStartParams {
   implicit val codec: JsonValueCodec[TaskStartParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class TaskProgressParams(
@@ -866,7 +866,7 @@ final case class TaskProgressParams(
 
 object TaskProgressParams {
   implicit val codec: JsonValueCodec[TaskProgressParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class TaskFinishParams(
@@ -880,7 +880,7 @@ final case class TaskFinishParams(
 
 object TaskFinishParams {
   implicit val codec: JsonValueCodec[TaskFinishParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 object TaskDataKind {
@@ -920,7 +920,7 @@ final case class JvmBuildTarget(
 
 object JvmBuildTarget {
   implicit val codec: JsonValueCodec[JvmBuildTarget] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class ScalaBuildTarget(
@@ -934,7 +934,7 @@ final case class ScalaBuildTarget(
 
 object ScalaBuildTarget {
   implicit val codec: JsonValueCodec[ScalaBuildTarget] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class ScalaTestParams(
@@ -944,7 +944,7 @@ final case class ScalaTestParams(
 
 object ScalaTestParams {
   implicit val codec: JsonValueCodec[ScalaTestParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 object TestParamsDataKind {
@@ -958,7 +958,7 @@ final case class ScalacOptionsParams(
 
 object ScalacOptionsParams {
   implicit val codec: JsonValueCodec[ScalacOptionsParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class JvmTestEnvironmentParams(
@@ -968,7 +968,7 @@ final case class JvmTestEnvironmentParams(
 
 object JvmTestEnvironmentParams {
   implicit val codec: JsonValueCodec[JvmTestEnvironmentParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class JvmEnvironmentItem(
@@ -981,7 +981,7 @@ final case class JvmEnvironmentItem(
 
 object JvmEnvironmentItem {
   implicit val codec: JsonValueCodec[JvmEnvironmentItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class JvmTestEnvironmentResult(
@@ -990,7 +990,7 @@ final case class JvmTestEnvironmentResult(
 
 object JvmTestEnvironmentResult {
   implicit val codec: JsonValueCodec[JvmTestEnvironmentResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class JvmRunEnvironmentParams(
@@ -1000,7 +1000,7 @@ final case class JvmRunEnvironmentParams(
 
 object JvmRunEnvironmentParams {
   implicit val codec: JsonValueCodec[JvmRunEnvironmentParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class JvmRunEnvironmentResult(
@@ -1009,7 +1009,7 @@ final case class JvmRunEnvironmentResult(
 
 object JvmRunEnvironmentResult {
   implicit val codec: JsonValueCodec[JvmRunEnvironmentResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class ScalacOptionsItem(
@@ -1021,7 +1021,7 @@ final case class ScalacOptionsItem(
 
 object ScalacOptionsItem {
   implicit val codec: JsonValueCodec[ScalacOptionsItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class ScalacOptionsResult(
@@ -1030,7 +1030,7 @@ final case class ScalacOptionsResult(
 
 object ScalacOptionsResult {
   implicit val codec: JsonValueCodec[ScalacOptionsResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 // Request: 'buildTarget/scalaTestClasses', C -> S
@@ -1041,7 +1041,7 @@ final case class ScalaTestClassesParams(
 
 object ScalaTestClassesParams {
   implicit val codec: JsonValueCodec[ScalaTestClassesParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class ScalaTestClassesItem(
@@ -1052,7 +1052,7 @@ final case class ScalaTestClassesItem(
 
 object ScalaTestClassesItem {
   implicit val codec: JsonValueCodec[ScalaTestClassesItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class ScalaTestClassesResult(
@@ -1061,7 +1061,7 @@ final case class ScalaTestClassesResult(
 
 object ScalaTestClassesResult {
   implicit val codec: JsonValueCodec[ScalaTestClassesResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 // Request: 'buildTarget/scalaMainClasses', C -> S
@@ -1072,7 +1072,7 @@ final case class ScalaMainClassesParams(
 
 object ScalaMainClassesParams {
   implicit val codec: JsonValueCodec[ScalaMainClassesParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class ScalaMainClass(
@@ -1084,7 +1084,7 @@ final case class ScalaMainClass(
 
 object ScalaMainClass {
   implicit val codec: JsonValueCodec[ScalaMainClass] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class ScalaMainClassesItem(
@@ -1095,7 +1095,7 @@ final case class ScalaMainClassesItem(
 
 object ScalaMainClassesItem {
   implicit val codec: JsonValueCodec[ScalaMainClassesItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class ScalaMainClassesResult(
@@ -1104,7 +1104,7 @@ final case class ScalaMainClassesResult(
 
 object ScalaMainClassesResult {
   implicit val codec: JsonValueCodec[ScalaMainClassesResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class SbtBuildTarget(
@@ -1117,7 +1117,7 @@ final case class SbtBuildTarget(
 
 object SbtBuildTarget {
   implicit val codec: JsonValueCodec[SbtBuildTarget] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class BspConnectionDetails(
@@ -1130,7 +1130,7 @@ final case class BspConnectionDetails(
 
 object BspConnectionDetails {
   implicit val codec: JsonValueCodec[BspConnectionDetails] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class DebugSessionParams(
@@ -1141,7 +1141,7 @@ final case class DebugSessionParams(
 
 object DebugSessionParams {
   implicit val codec: JsonValueCodec[DebugSessionParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 object DebugSessionParamsDataKind {
@@ -1154,7 +1154,7 @@ final case class DebugSessionAddress(uri: String)
 
 object DebugSessionAddress {
   implicit val codec: JsonValueCodec[DebugSessionAddress] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class JavacOptionsParams(
@@ -1163,7 +1163,7 @@ final case class JavacOptionsParams(
 
 object JavacOptionsParams {
   implicit val codec: JsonValueCodec[JavacOptionsParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class JavacOptionsItem(
@@ -1175,7 +1175,7 @@ final case class JavacOptionsItem(
 
 object JavacOptionsItem {
   implicit val codec: JsonValueCodec[JavacOptionsItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class JavacOptionsResult(
@@ -1184,7 +1184,7 @@ final case class JavacOptionsResult(
 
 object JavacOptionsResult {
   implicit val codec: JsonValueCodec[JavacOptionsResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class CppBuildTarget(
@@ -1196,7 +1196,7 @@ final case class CppBuildTarget(
 
 object CppBuildTarget {
   implicit val codec: JsonValueCodec[CppBuildTarget] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class CppOptionsParams(
@@ -1205,7 +1205,7 @@ final case class CppOptionsParams(
 
 object CppOptionsParams {
   implicit val codec: JsonValueCodec[CppOptionsParams] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class CppOptionsItem(
@@ -1218,7 +1218,7 @@ final case class CppOptionsItem(
 
 object CppOptionsItem {
   implicit val codec: JsonValueCodec[CppOptionsItem] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class CppOptionsResult(
@@ -1227,5 +1227,5 @@ final case class CppOptionsResult(
 
 object CppOptionsResult {
   implicit val codec: JsonValueCodec[CppOptionsResult] =
-    JsonCodecMaker.make(CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
@@ -1,7 +1,8 @@
 package ch.epfl.scala.bsp
 package endpoints
 
-import scala.meta.jsonrpc.Endpoint
+import jsonrpc4s.Endpoint
+import jsonrpc4s.Endpoint.unitCodec
 
 object Build extends Build
 trait Build {
@@ -33,8 +34,11 @@ trait BuildTarget {
       extends Endpoint[InverseSourcesParams, InverseSourcesResult]("buildTarget/inverseSources")
   object dependencySources
       extends Endpoint[DependencySourcesParams, DependencySourcesResult](
-        "buildTarget/dependencySources")
+        "buildTarget/dependencySources"
+      )
+
   object dependencyModules extends Endpoint[DependencyModulesParams, DependencyModulesResult]("buildTarget/dependencyModules")
+
   object resources extends Endpoint[ResourcesParams, ResourcesResult]("buildTarget/resources")
 
   // Scala specific endpoints
@@ -42,16 +46,20 @@ trait BuildTarget {
       extends Endpoint[ScalacOptionsParams, ScalacOptionsResult]("buildTarget/scalacOptions")
   object scalaTestClasses
       extends Endpoint[ScalaTestClassesParams, ScalaTestClassesResult](
-        "buildTarget/scalaTestClasses")
+        "buildTarget/scalaTestClasses"
+      )
   object scalaMainClasses
       extends Endpoint[ScalaMainClassesParams, ScalaMainClassesResult](
-        "buildTarget/scalaMainClasses")
+        "buildTarget/scalaMainClasses"
+      )
   object jvmTestEnvironment
-    extends Endpoint[JvmTestEnvironmentParams, JvmTestEnvironmentResult](
-      "buildTarget/jvmTestEnvironment")
+      extends Endpoint[JvmTestEnvironmentParams, JvmTestEnvironmentResult](
+        "buildTarget/jvmTestEnvironment"
+      )
   object jvmRunEnvironment
     extends Endpoint[JvmRunEnvironmentParams, JvmRunEnvironmentResult](
-      "buildTarget/jvmRunEnvironment")
+      "buildTarget/jvmRunEnvironment"
+    )
   // Java specific endpoints
   object javacOptions
     extends Endpoint[JavacOptionsParams, JavacOptionsResult](
@@ -68,7 +76,8 @@ object Workspace extends Workspace
 trait Workspace {
   object buildTargets
       extends Endpoint[WorkspaceBuildTargetsRequest, WorkspaceBuildTargetsResult](
-        "workspace/buildTargets")
+        "workspace/buildTargets"
+      )
   object reload extends Endpoint[Reload, Unit]("workspace/reload")
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val bsp4s = project
     Test / publishArtifact := false,
     Compile / doc / sources := Nil,
     libraryDependencies ++= List(
-      "me.vican.jorge" %% "jsonrpc4s" % "1.0.0+23-a0cabe67",
+      "me.vican.jorge" %% "jsonrpc4s" % "0.1.0",
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.8.2"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 inThisBuild(
   List(
-    scalaVersion := "2.12.11",
+    scalaVersion := "2.12.13",
     organization := "ch.epfl.scala",
     homepage := Some(url("https://github.com/build-server-protocol/build-server-protocol")),
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
@@ -51,7 +51,7 @@ lazy val bsp4s = project
     Compile / doc / sources := Nil,
     libraryDependencies ++= List(
       "me.vican.jorge" %% "jsonrpc4s" % "1.0.0+23-a0cabe67",
-      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.6.0"
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.8.2"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,31 @@
-inThisBuild(List(
-  scalaVersion := "2.12.11",
-  organization := "ch.epfl.scala",
-  homepage := Some(url("https://github.com/build-server-protocol/build-server-protocol")),
-  licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
-  developers := List(
-      Developer("olafurpg", "Ólafur Páll Geirsson", "olafurpg@gmail.com", url("https://github.com/olafurpg")),
-      Developer("jvican", "Jorge Vicente Cantero", "jorge@vican.me", url("https://github.com/jvican")),
-      Developer("jastice", "Justin Kaeser", "justin@justinkaeser.com", url("https://github.com/jastice")),
+inThisBuild(
+  List(
+    scalaVersion := "2.12.11",
+    organization := "ch.epfl.scala",
+    homepage := Some(url("https://github.com/build-server-protocol/build-server-protocol")),
+    licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+    developers := List(
+      Developer(
+        "olafurpg",
+        "Ólafur Páll Geirsson",
+        "olafurpg@gmail.com",
+        url("https://github.com/olafurpg")
+      ),
+      Developer(
+        "jvican",
+        "Jorge Vicente Cantero",
+        "jorge@vican.me",
+        url("https://github.com/jvican")
+      ),
+      Developer(
+        "jastice",
+        "Justin Kaeser",
+        "justin@justinkaeser.com",
+        url("https://github.com/jastice")
+      )
+    )
   )
-))
+)
 
 import java.io.File
 import org.eclipse.xtend.core.XtendInjectorSingleton
@@ -32,12 +49,9 @@ lazy val bsp4s = project
   .settings(
     Test / publishArtifact := false,
     Compile / doc / sources := Nil,
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
     libraryDependencies ++= List(
-      "io.circe" %% "circe-core" % "0.9.0",
-      "io.circe" %% "circe-derivation" % "0.9.0-M4",
-      "io.circe" %% "circe-generic-extras" % "0.9.0",
-      "org.scalameta" %% "lsp4s" % "0.2.0"
+      "me.vican.jorge" %% "jsonrpc4s" % "1.0.0+23-a0cabe67",
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.6.0"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,8 @@ lazy val tests = project
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
       "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0",
       "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.0.0",
-      "org.scalatest" %% "scalatest" % "3.0.5"
+      "org.scalatest" %% "scalatest" % "3.0.5",
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.8.2"
     )
   )
   .dependsOn(bsp4s, bsp4j, `bsp-testkit`)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.9")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.21")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.12")
 
 libraryDependencies ++= Seq(

--- a/tests/src/test/scala/tests/SerializationPropertySuite.scala
+++ b/tests/src/test/scala/tests/SerializationPropertySuite.scala
@@ -4,25 +4,30 @@ import ch.epfl.scala.bsp.testkit.gen.Bsp4jGenerators
 import ch.epfl.scala.bsp.testkit.gen.bsp4jArbitrary._
 import ch.epfl.scala.{bsp4j, bsp => bsp4s}
 import com.google.gson.{Gson, GsonBuilder}
-import io.circe.parser.decode
-import io.circe.syntax._
-import io.circe.{Decoder, Encoder}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{Assertion, Assertions, FunSuite}
+import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
+import com.github.plokhotnyuk.jsoniter_scala.core.writeToString
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import scala.util.Try
+import scala.util.Failure
+import scala.util.Success
 
 class SerializationPropertySuite extends FunSuite with GeneratorDrivenPropertyChecks {
 
   implicit val gson: Gson = new GsonBuilder().setPrettyPrinting().create()
 
-  def assertSerializationRoundtrip[T4j,T4s](bsp4jValue: T4j)(implicit encoder: Encoder[T4s], decoder: Decoder[T4s]): Assertion = {
+  def assertSerializationRoundtrip[T4j, T4s](
+      bsp4jValue: T4j
+  )(implicit codec: JsonValueCodec[T4s]): Assertion = {
     val bsp4jJson = gson.toJson(bsp4jValue)
-    val bsp4sValueDecoded = decode[T4s](bsp4jJson) match {
-      case Left(problem) =>
-        if (problem.getCause == null) Assertions.fail(problem.getMessage)
-        else Assertions.fail(problem.getMessage, problem.getCause)
-      case Right(value) => value
+
+    val bsp4sValueDecoded = Try(readFromString(bsp4jJson)) match {
+      case Failure(exception) =>
+        Assertions.fail(exception.getMessage())
+      case Success(value) => value
     }
-    val bsp4sJson = bsp4sValueDecoded.asJson.toString()
+    val bsp4sJson = writeToString(bsp4sValueDecoded)
     val bsp4jValueDecoded = gson.fromJson[T4j](bsp4sJson, bsp4jValue.getClass)
 
     assert(bsp4jValue == bsp4jValueDecoded)
@@ -30,17 +35,21 @@ class SerializationPropertySuite extends FunSuite with GeneratorDrivenPropertyCh
 
   test("BspConnectionDetails") {
     forAll { bspConnectionDetails: bsp4j.BspConnectionDetails =>
-      assertSerializationRoundtrip[bsp4j.BspConnectionDetails, bsp4s.BspConnectionDetails](bspConnectionDetails)
+      assertSerializationRoundtrip[bsp4j.BspConnectionDetails, bsp4s.BspConnectionDetails](
+        bspConnectionDetails
+      )
     }
   }
   test("BuildClientCapabilities") {
-    forAll { buildClientCapabilities: bsp4j.BuildClientCapabilities  =>
-      assertSerializationRoundtrip[bsp4j.BuildClientCapabilities, bsp4s.BuildClientCapabilities](buildClientCapabilities)
+    forAll { buildClientCapabilities: bsp4j.BuildClientCapabilities =>
+      assertSerializationRoundtrip[bsp4j.BuildClientCapabilities, bsp4s.BuildClientCapabilities](
+        buildClientCapabilities
+      )
     }
   }
   test("BuildServerCapabilities") {
     forAll { a: bsp4j.BuildServerCapabilities =>
-      assertSerializationRoundtrip[bsp4j.BuildServerCapabilities,bsp4s.BuildServerCapabilities](a)
+      assertSerializationRoundtrip[bsp4j.BuildServerCapabilities, bsp4s.BuildServerCapabilities](a)
     }
   }
   test("BuildTarget") {
@@ -130,7 +139,10 @@ class SerializationPropertySuite extends FunSuite with GeneratorDrivenPropertyCh
   }
   test("DiagnosticRelatedInformation") {
     forAll { a: bsp4j.DiagnosticRelatedInformation =>
-      assertSerializationRoundtrip[bsp4j.DiagnosticRelatedInformation, bsp4s.DiagnosticRelatedInformation](a)
+      assertSerializationRoundtrip[
+        bsp4j.DiagnosticRelatedInformation,
+        bsp4s.DiagnosticRelatedInformation
+      ](a)
     }
   }
   test("DiagnosticSeverity") {
@@ -185,7 +197,9 @@ class SerializationPropertySuite extends FunSuite with GeneratorDrivenPropertyCh
   }
   test("PublishDiagnosticsParams") {
     forAll { a: bsp4j.PublishDiagnosticsParams =>
-      assertSerializationRoundtrip[bsp4j.PublishDiagnosticsParams, bsp4s.PublishDiagnosticsParams](a)
+      assertSerializationRoundtrip[bsp4j.PublishDiagnosticsParams, bsp4s.PublishDiagnosticsParams](
+        a
+      )
     }
   }
   test("Range") {
@@ -395,17 +409,24 @@ class SerializationPropertySuite extends FunSuite with GeneratorDrivenPropertyCh
   }
   test("WorkspaceBuildTargetsResult") {
     forAll { a: bsp4j.WorkspaceBuildTargetsResult =>
-      assertSerializationRoundtrip[bsp4j.WorkspaceBuildTargetsResult, bsp4s.WorkspaceBuildTargetsResult](a)
+      assertSerializationRoundtrip[
+        bsp4j.WorkspaceBuildTargetsResult,
+        bsp4s.WorkspaceBuildTargetsResult
+      ](a)
     }
   }
   test("JvmTestEnvironmentParams") {
     forAll { a: bsp4j.JvmTestEnvironmentParams =>
-      assertSerializationRoundtrip[bsp4j.JvmTestEnvironmentParams, bsp4s.JvmTestEnvironmentParams](a)
+      assertSerializationRoundtrip[bsp4j.JvmTestEnvironmentParams, bsp4s.JvmTestEnvironmentParams](
+        a
+      )
     }
   }
   test("JvmTestEnvironmentResult") {
     forAll { a: bsp4j.JvmTestEnvironmentResult =>
-      assertSerializationRoundtrip[bsp4j.JvmTestEnvironmentResult, bsp4s.JvmTestEnvironmentResult](a)
+      assertSerializationRoundtrip[bsp4j.JvmTestEnvironmentResult, bsp4s.JvmTestEnvironmentResult](
+        a
+      )
     }
   }
   test("JvmRunEnvironmentParams") {

--- a/tests/src/test/scala/tests/SerializationSuite.scala
+++ b/tests/src/test/scala/tests/SerializationSuite.scala
@@ -34,7 +34,7 @@ class SerializationSuite extends FunSuite {
     val bsp4sJson = writeToString(bsp4sValue)
     val bsp4jValue = gson.fromJson(bsp4sJson, classOf[bsp4j.TaskFinishParams])
     val bsp4jJson = gson.toJson(bsp4jValue)
-    val bsp4sValueDecoded = readFromString[bsp4s.TaskFinishParams](bsp4jJson)
+    val bsp4sValueDecoded = readFromString[bsp4s.TaskFinishParams](bsp4sJson)
 
     val bsp4jValueData =
       gson.fromJson(bsp4jValue.getData.asInstanceOf[JsonElement], classOf[bsp4j.CompileReport])

--- a/tests/src/test/scala/tests/TypoSuite.scala
+++ b/tests/src/test/scala/tests/TypoSuite.scala
@@ -38,6 +38,8 @@ import jsonrpc4s.InputOutput
 import monix.eval.Task
 import jsonrpc4s.RpcSuccess
 import jsonrpc4s.RpcFailure
+import scala.util.Failure
+import scala.util.Success
 
 class TypoSuite extends FunSuite {
 
@@ -49,7 +51,7 @@ class TypoSuite extends FunSuite {
   val textDocumentIdentifiers: util.List[TextDocumentIdentifier] =
     Collections.singletonList(textDocumentIdentifier)
 
-  // Java build client that ignored all notifications.
+  // Java build client that ignores all notifications.
   val silentJavaClient: BuildClient = new BuildClient {
     override def onBuildShowMessage(params: ShowMessageParams): Unit =
       ()
@@ -67,7 +69,7 @@ class TypoSuite extends FunSuite {
       ()
   }
 
-  // Java server client that responds with hardcoded constants
+  // Java build server that responds with hardcoded constants
   val hardcodedJavaServer: BuildServer = new BuildServer {
 
     override def buildInitialize(
@@ -420,7 +422,7 @@ class TypoSuite extends FunSuite {
         val expected = trace2.toString()
         assertNoDiff(obtained, expected)
       }
-      Await.result(result, Duration("5s"))
+      Await.result(result, Duration("20s"))
     } finally {
       allResources.cancel()
     }

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -12,6 +12,10 @@
       "bsp": {
         "title": "bsp"
       },
+      "extensions/cpp": {
+        "title": "C++ Extension",
+        "sidebar_label": "cpp"
+      },
       "extensions/java": {
         "title": "Java Extension",
         "sidebar_label": "Java"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -12,10 +12,6 @@
       "bsp": {
         "title": "bsp"
       },
-      "extensions/cpp": {
-        "title": "C++ Extension",
-        "sidebar_label": "cpp"
-      },
       "extensions/java": {
         "title": "Java Extension",
         "sidebar_label": "Java"


### PR DESCRIPTION
This is a continuation of the work that @jvican did in #125.

> Removes dependency on circe, we now only depend on jsoniter-scala itself
for JSON purposes, which is a library with no third-party dependencies.

I rebased on the current main branch and brought this up to date with the aim
to unlock #153.

~Note that that also includes the work in #174, so you may want to merge that in first.~