### PR TITLE
Update lsp4j to 0.9.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,8 +70,8 @@ lazy val bsp4j = project
     },
     Compile / unmanagedSourceDirectories += (Compile / sourceDirectory).value / "xtend-gen",
     libraryDependencies ++= List(
-      "org.eclipse.lsp4j" % "org.eclipse.lsp4j.generator" % "0.8.1",
-      "org.eclipse.lsp4j" % "org.eclipse.lsp4j.jsonrpc" % "0.8.1"
+      "org.eclipse.lsp4j" % "org.eclipse.lsp4j.generator" % "0.9.0",
+      "org.eclipse.lsp4j" % "org.eclipse.lsp4j.jsonrpc" % "0.9.0"
     )
   )
 


### PR DESCRIPTION
I don't really know what I'm doing, but I need a more recent version of guava, and that seems to do the trick. `sbt test` succeeds. I did not update to a more recent version as starting from lsp4j 0.10.0 the test fails (and I have not idea how to fix them)