### PR TITLE
Enforce scalafmt

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# It's a good idea to ignore the following commits from git blame.
+# You can read more about this here if you're unfamiliar:
+# https://www.moxio.com/blog/43/ignoring-bulk-change-commits-with-git-blame
+#
+ccb5152da9b44b5891858d9370ec944efcc5c49f

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,3 +32,12 @@ jobs:
         with:
           java-version: adopt@1.8
       - run: sbt docs/docusaurusCreateSite
+  format-check:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-scala@v11
+        with:
+            java-version: adopt@1.8
+      - run: sbt checkScalaFormat

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,3 @@
 version = "2.7.5"
 maxColumn = 100
+project.git = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,3 +12,11 @@ sbt
 > ~; bsp4j/xtend ; bsp4j/compile
 ```
 
+## Formatting
+
+To ensure the Scala sources are formatted correctly you can run:
+
+```sh
+sbt scalaFormat
+```
+

--- a/build.sbt
+++ b/build.sbt
@@ -143,3 +143,13 @@ lazy val docs = project
     )
   )
   .enablePlugins(DocusaurusPlugin)
+
+addCommandAlias(
+  "scalaFormat",
+  "scalafmtAll ; scalafmtSbt"
+)
+
+addCommandAlias(
+  "checkScalaFormat",
+  "scalafmtCheckAll ; scalafmtSbtCheck"
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.21")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.25")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
 libraryDependencies ++= Seq(
   "org.eclipse.xtend" % "org.eclipse.xtend.core" % "2.25.0",


### PR DESCRIPTION
So this is a bit opinionated, but I noticed there was a `.scalafmt.conf` file, but it wasn't enforced at all. This also resulted in quite a few different indentation styles throughout the Scala sources. This pr adds in the sbt-scalafmt plugin, runs it with the existing configuration, and adds a check into CI to enforce formatting.

I don't have strong opinions on the type of formatting at all, just strong feelings on using it and being consistent. So if you want something switched, let me know. Or if you don't want this enabled at all, let me know and I can just remove the `.scalafmt.conf` file.

Note that I also added an extra commit to add in the `.git-blame-ignore-revs`. I've been using this lately in projects where I add in formatting since it combats the "now my git blame is useless" argument. Locally you can just:

```sh
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

And then your tooling that utilizes `git blame` will ignore the commit listed in the file.

Let me know your thoughts if this is all ok with you all.