### PR TITLE
Add in `noOp` field to `CompileReport`.

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -436,6 +436,7 @@ class CompileReport {
   @NonNull Integer errors
   @NonNull Integer warnings
   Long time
+  Boolean noOp
   new(@NonNull BuildTargetIdentifier target, @NonNull Integer errors, @NonNull Integer warnings) {
     this.target = target
     this.errors = errors

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileReport.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileReport.java
@@ -20,6 +20,8 @@ public class CompileReport {
   
   private Long time;
   
+  private Boolean noOp;
+  
   public CompileReport(@NonNull final BuildTargetIdentifier target, @NonNull final Integer errors, @NonNull final Integer warnings) {
     this.target = target;
     this.errors = errors;
@@ -74,6 +76,15 @@ public class CompileReport {
     this.time = time;
   }
   
+  @Pure
+  public Boolean getNoOp() {
+    return this.noOp;
+  }
+  
+  public void setNoOp(final Boolean noOp) {
+    this.noOp = noOp;
+  }
+  
   @Override
   @Pure
   public String toString() {
@@ -83,6 +94,7 @@ public class CompileReport {
     b.add("errors", this.errors);
     b.add("warnings", this.warnings);
     b.add("time", this.time);
+    b.add("noOp", this.noOp);
     return b.toString();
   }
   
@@ -121,6 +133,11 @@ public class CompileReport {
         return false;
     } else if (!this.time.equals(other.time))
       return false;
+    if (this.noOp == null) {
+      if (other.noOp != null)
+        return false;
+    } else if (!this.noOp.equals(other.noOp))
+      return false;
     return true;
   }
   
@@ -133,6 +150,7 @@ public class CompileReport {
     result = prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
     result = prime * result + ((this.errors== null) ? 0 : this.errors.hashCode());
     result = prime * result + ((this.warnings== null) ? 0 : this.warnings.hashCode());
-    return prime * result + ((this.time== null) ? 0 : this.time.hashCode());
+    result = prime * result + ((this.time== null) ? 0 : this.time.hashCode());
+    return prime * result + ((this.noOp== null) ? 0 : this.noOp.hashCode());
   }
 }

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -679,7 +679,8 @@ final case class CompileReport(
     originId: Option[String],
     errors: Int,
     warnings: Int,
-    time: Option[Long]
+    time: Option[Long],
+    noOp: Option[Boolean]
 )
 
 object CompileReport {

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1138,7 +1138,10 @@ export interface CompileReport {
   warnings: Int;
 
   /** The total number of milliseconds it took to compile the target. */
-  time?: Int];
+  time?: Int;
+
+  /** The compilation was a noOp compilation. */
+  noOp?: Boolean;
 }
 ```
 

--- a/tests/src/test/scala/tests/SerializationSuite.scala
+++ b/tests/src/test/scala/tests/SerializationSuite.scala
@@ -21,7 +21,7 @@ class SerializationSuite extends FunSuite {
 
     val target = bsp4s.BuildTargetIdentifier(bsp4s.Uri(buildTarget))
     val id = bsp4s.TaskId("task", Some(List("p1", "p2", "p3")))
-    val report = bsp4s.CompileReport(target, Some("origin"), 13, 12, Some(77))
+    val report = bsp4s.CompileReport(target, Some("origin"), 13, 12, Some(77), None)
     val bsp4sValue = bsp4s.TaskFinishParams(
       id,
       Some(12345),


### PR DESCRIPTION
This is meant to close #148 by adding in another field to the
`CompileReport` to signify to the client that the compilation was a
no-op. This is useful for some clients that trigger things based on
compliations, and they want to skip that trigger if the compilation was
a no-op. Currently this is accomplished by looking for keywords in the
message as is the case with Metals and Bloop.