### PR TITLE
Fix #205: Add operation to get output paths

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
@@ -37,6 +37,9 @@ public interface BuildServer {
     @JsonRequest("buildTarget/resources")
     CompletableFuture<ResourcesResult> buildTargetResources(ResourcesParams params);
 
+    @JsonRequest("buildTarget/outputPaths")
+    CompletableFuture<OutputPathsResult> buildTargetOutputPaths(OutputPathsParams params);
+
     @JsonRequest("buildTarget/compile")
     CompletableFuture<CompileResult> buildTargetCompile(CompileParams params);
 

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/OutputPathItemKind.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/OutputPathItemKind.java
@@ -1,0 +1,28 @@
+package ch.epfl.scala.bsp4j;
+
+import com.google.gson.annotations.JsonAdapter;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.EnumTypeAdapter;
+
+@JsonAdapter(EnumTypeAdapter.Factory.class)
+public enum OutputPathItemKind {
+
+    FILE(1),
+    DIRECTORY(2);
+
+    private final int value;
+
+    OutputPathItemKind(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static OutputPathItemKind forValue(int value) {
+        OutputPathItemKind[] allValues = OutputPathItemKind.values();
+        if (value < 1 || value > allValues.length)
+            throw new IllegalArgumentException("Illegal enum value: " + value);
+        return allValues[value - 1];
+    }
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -147,6 +147,7 @@ class BuildServerCapabilities {
   Boolean dependencySourcesProvider
   Boolean dependencyModulesProvider
   Boolean resourcesProvider
+  Boolean outputPathsProvider
   Boolean buildTargetChangedProvider
   Boolean jvmRunEnvironmentProvider
   Boolean jvmTestEnvironmentProvider
@@ -404,6 +405,43 @@ class ResourcesItem {
   new(@NonNull BuildTargetIdentifier target, @NonNull List<String> resources) {
     this.target = target
     this.resources = resources
+  }
+}
+
+@JsonRpcData
+class OutputPathsParams {
+  @NonNull List<BuildTargetIdentifier> targets
+  new(@NonNull List<BuildTargetIdentifier> targets) {
+    this.targets = targets
+  }
+}
+
+@JsonRpcData
+class OutputPathsResult {
+  @NonNull List<OutputPathsItem> items
+  new(@NonNull List<OutputPathsItem> items) {
+    this.items = items
+  }
+}
+
+@JsonRpcData
+class OutputPathsItem {
+  @NonNull BuildTargetIdentifier target
+  @NonNull List<OutputPathItem> outputPaths
+  new(@NonNull BuildTargetIdentifier target, @NonNull List<OutputPathItem> outputPaths) {
+    this.target = target
+    this.outputPaths = outputPaths
+  }
+}
+
+@JsonRpcData
+class OutputPathItem {
+  @NonNull String uri
+  @NonNull OutputPathItemKind kind
+
+  new(@NonNull String uri, @NonNull OutputPathItemKind kind) {
+    this.uri = uri
+    this.kind = kind
   }
 }
 

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildServerCapabilities.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildServerCapabilities.java
@@ -20,7 +20,9 @@ public class BuildServerCapabilities {
   private Boolean dependencyModulesProvider;
   
   private Boolean resourcesProvider;
-  
+
+  private Boolean outputPathsProvider;
+
   private Boolean buildTargetChangedProvider;
   
   private Boolean jvmRunEnvironmentProvider;
@@ -100,7 +102,16 @@ public class BuildServerCapabilities {
   public void setResourcesProvider(final Boolean resourcesProvider) {
     this.resourcesProvider = resourcesProvider;
   }
-  
+
+  @Pure
+  public Boolean getOutputPathsProvider() {
+    return this.outputPathsProvider;
+  }
+
+  public void setOutputPathsProvider(final Boolean outputPathsProvider) {
+    this.outputPathsProvider = outputPathsProvider;
+  }
+
   @Pure
   public Boolean getBuildTargetChangedProvider() {
     return this.buildTargetChangedProvider;
@@ -149,6 +160,7 @@ public class BuildServerCapabilities {
     b.add("dependencySourcesProvider", this.dependencySourcesProvider);
     b.add("dependencyModulesProvider", this.dependencyModulesProvider);
     b.add("resourcesProvider", this.resourcesProvider);
+    b.add("outputPathsProvider", this.outputPathsProvider);
     b.add("buildTargetChangedProvider", this.buildTargetChangedProvider);
     b.add("jvmRunEnvironmentProvider", this.jvmRunEnvironmentProvider);
     b.add("jvmTestEnvironmentProvider", this.jvmTestEnvironmentProvider);
@@ -206,6 +218,11 @@ public class BuildServerCapabilities {
         return false;
     } else if (!this.resourcesProvider.equals(other.resourcesProvider))
       return false;
+    if (this.outputPathsProvider == null) {
+      if (other.outputPathsProvider != null)
+        return false;
+    } else if (!this.outputPathsProvider.equals(other.outputPathsProvider))
+      return false;
     if (this.buildTargetChangedProvider == null) {
       if (other.buildTargetChangedProvider != null)
         return false;
@@ -242,6 +259,7 @@ public class BuildServerCapabilities {
     result = prime * result + ((this.dependencySourcesProvider== null) ? 0 : this.dependencySourcesProvider.hashCode());
     result = prime * result + ((this.dependencyModulesProvider== null) ? 0 : this.dependencyModulesProvider.hashCode());
     result = prime * result + ((this.resourcesProvider== null) ? 0 : this.resourcesProvider.hashCode());
+    result = prime * result + ((this.outputPathsProvider== null) ? 0 : this.outputPathsProvider.hashCode());
     result = prime * result + ((this.buildTargetChangedProvider== null) ? 0 : this.buildTargetChangedProvider.hashCode());
     result = prime * result + ((this.jvmRunEnvironmentProvider== null) ? 0 : this.jvmRunEnvironmentProvider.hashCode());
     result = prime * result + ((this.jvmTestEnvironmentProvider== null) ? 0 : this.jvmTestEnvironmentProvider.hashCode());

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/OutputPathItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/OutputPathItem.java
@@ -1,0 +1,81 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class OutputPathItem {
+  @NonNull
+  private String uri;
+
+  @NonNull
+  private OutputPathItemKind kind;
+
+  public OutputPathItem(@NonNull final String uri, @NonNull final OutputPathItemKind kind) {
+    this.uri = uri;
+    this.kind = kind;
+  }
+
+  @Pure
+  @NonNull
+  public String getUri() {
+    return this.uri;
+  }
+
+  public void setUri(@NonNull final String uri) {
+    this.uri = Preconditions.checkNotNull(uri, "uri");
+  }
+
+  @Pure
+  @NonNull
+  public OutputPathItemKind getKind() {
+    return this.kind;
+  }
+
+  public void setKind(@NonNull final OutputPathItemKind kind) {
+    this.kind = Preconditions.checkNotNull(kind, "kind");
+  }
+
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("uri", this.uri);
+    b.add("kind", this.kind);
+    return b.toString();
+  }
+
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    OutputPathItem other = (OutputPathItem) obj;
+    if (this.uri == null) {
+      if (other.uri != null)
+        return false;
+    } else if (!this.uri.equals(other.uri))
+      return false;
+    if (this.kind == null) {
+      if (other.kind != null)
+        return false;
+    } else if (!this.kind.equals(other.kind))
+      return false;
+    return true;
+  }
+
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.uri== null) ? 0 : this.uri.hashCode());
+    return prime * result + ((this.kind== null) ? 0 : this.kind.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/OutputPathsItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/OutputPathsItem.java
@@ -1,0 +1,82 @@
+package ch.epfl.scala.bsp4j;
+
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class OutputPathsItem {
+  @NonNull
+  private BuildTargetIdentifier target;
+
+  @NonNull
+  private List<OutputPathItem> outputPaths;
+
+  public OutputPathsItem(@NonNull final BuildTargetIdentifier target, @NonNull final List<OutputPathItem> outputPaths) {
+    this.target = target;
+    this.outputPaths = outputPaths;
+  }
+
+  @Pure
+  @NonNull
+  public BuildTargetIdentifier getTarget() {
+    return this.target;
+  }
+
+  public void setTarget(@NonNull final BuildTargetIdentifier target) {
+    this.target = Preconditions.checkNotNull(target, "target");
+  }
+
+  @Pure
+  @NonNull
+  public List<OutputPathItem> getOutputPaths() {
+    return this.outputPaths;
+  }
+
+  public void setOutputPaths(@NonNull final List<OutputPathItem> outputPaths) {
+    this.outputPaths = Preconditions.checkNotNull(outputPaths, "outputPaths");
+  }
+
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("target", this.target);
+    b.add("outputPaths", this.outputPaths);
+    return b.toString();
+  }
+
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    OutputPathsItem other = (OutputPathsItem) obj;
+    if (this.target == null) {
+      if (other.target != null)
+        return false;
+    } else if (!this.target.equals(other.target))
+      return false;
+    if (this.outputPaths == null) {
+      if (other.outputPaths != null)
+        return false;
+    } else if (!this.outputPaths.equals(other.outputPaths))
+      return false;
+    return true;
+  }
+
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.target== null) ? 0 : this.target.hashCode());
+    return prime * result + ((this.outputPaths== null) ? 0 : this.outputPaths.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/OutputPathsParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/OutputPathsParams.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class OutputPathsParams {
+  @NonNull
+  private List<BuildTargetIdentifier> targets;
+
+  public OutputPathsParams(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getTargets() {
+    return this.targets;
+  }
+
+  public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = Preconditions.checkNotNull(targets, "targets");
+  }
+
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    return b.toString();
+  }
+
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    OutputPathsParams other = (OutputPathsParams) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    return true;
+  }
+
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.targets== null) ? 0 : this.targets.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/OutputPathsResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/OutputPathsResult.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class OutputPathsResult {
+  @NonNull
+  private List<OutputPathsItem> items;
+
+  public OutputPathsResult(@NonNull final List<OutputPathsItem> items) {
+    this.items = items;
+  }
+
+  @Pure
+  @NonNull
+  public List<OutputPathsItem> getItems() {
+    return this.items;
+  }
+
+  public void setItems(@NonNull final List<OutputPathsItem> items) {
+    this.items = Preconditions.checkNotNull(items, "items");
+  }
+
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("items", this.items);
+    return b.toString();
+  }
+
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    OutputPathsResult other = (OutputPathsResult) obj;
+    if (this.items == null) {
+      if (other.items != null)
+        return false;
+    } else if (!this.items.equals(other.items))
+      return false;
+    return true;
+  }
+
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.items== null) ? 0 : this.items.hashCode());
+  }
+}

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -217,6 +217,7 @@ final case class BuildServerCapabilities(
     dependencySourcesProvider: Option[Boolean],
     dependencyModulesProvider: Option[Boolean],
     resourcesProvider: Option[Boolean],
+    outputPathsProvider: Option[Boolean],
     buildTargetChangedProvider: Option[Boolean],
     jvmTestEnvironmentProvider: Option[Boolean],
     jvmRunEnvironmentProvider: Option[Boolean],
@@ -648,6 +649,63 @@ final case class ResourcesItem(
 object ResourcesItem {
   implicit val codec: JsonValueCodec[ResourcesItem] =
     JsonCodecMaker.makeWithRequiredCollectionFields
+}
+
+final case class OutputPathsParams(
+    targets: List[BuildTargetIdentifier]
+)
+
+object OutputPathsParams {
+  implicit val codec: JsonValueCodec[OutputPathsParams] =
+    JsonCodecMaker.makeWithRequiredCollectionFields
+}
+
+final case class OutputPathsResult(
+    items: List[OutputPathsItem]
+)
+
+object OutputPathsResult {
+  implicit val codec: JsonValueCodec[OutputPathsResult] =
+    JsonCodecMaker.makeWithRequiredCollectionFields
+}
+
+final case class OutputPathsItem(
+    target: BuildTargetIdentifier,
+    outputPaths: List[OutputPathItem]
+)
+
+object OutputPathsItem {
+  implicit val codec: JsonValueCodec[OutputPathsItem] =
+    JsonCodecMaker.makeWithRequiredCollectionFields
+}
+
+final case class OutputPathItem(
+    uri: Uri,
+    kind: OutputPathItemKind
+)
+
+object OutputPathItem {
+  implicit val codec: JsonValueCodec[OutputPathItem] =
+    JsonCodecMaker.makeWithRequiredCollectionFields
+}
+
+sealed abstract class OutputPathItemKind(val id: Int)
+object OutputPathItemKind {
+  object File extends OutputPathItemKind(1)
+  object Directory extends OutputPathItemKind(2)
+
+  implicit val codec: JsonValueCodec[OutputPathItemKind] = new JsonValueCodec[OutputPathItemKind] {
+    def nullValue: OutputPathItemKind = null
+    def encodeValue(item: OutputPathItemKind, out: JsonWriter): Unit =
+      out.writeVal(item.id)
+    def decodeValue(in: JsonReader, default: OutputPathItemKind): OutputPathItemKind = {
+      in.readInt() match {
+        case 1 => File
+        case 2 => Directory
+        case n => in.decodeError(s"Unknown source item kind id for $n")
+      }
+    }
+  }
 }
 
 // Request: 'buildTarget/compile', C -> S

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
@@ -44,6 +44,9 @@ trait BuildTarget {
 
   object resources extends Endpoint[ResourcesParams, ResourcesResult]("buildTarget/resources")
 
+  object outputPaths
+      extends Endpoint[OutputPathsParams, OutputPathsResult]("buildTarget/outputPaths")
+
   // Scala specific endpoints
   object scalacOptions
       extends Endpoint[ScalacOptionsParams, ScalacOptionsResult]("buildTarget/scalacOptions")

--- a/docs/bindings/java.md
+++ b/docs/bindings/java.md
@@ -167,6 +167,7 @@ class MyBuildServer extends BuildServer {
   def buildTargetDependencyModules(params: DependencyModulesParams): CompletableFuture[DependencyModulesResult] = ???
   def buildTargetInverseSources(params: InverseSourcesParams): CompletableFuture[InverseSourcesResult] = ???
   def buildTargetResources(params: ResourcesParams): CompletableFuture[ResourcesResult] = ???
+  def buildTargetOutputPaths(params: OutputPathsParams): CompletableFuture[OutputPathsResult] = ???
   def buildTargetRun(params: RunParams): CompletableFuture[RunResult] = ???
   def buildTargetSources(params: SourcesParams): CompletableFuture[SourcesResult] = ???
   def buildTargetTest(params: TestParams): CompletableFuture[TestResult] = ???

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -392,6 +392,10 @@ export interface BuildServerCapabilities {
    * via method buildTarget/resources */
   resourcesProvider?: Boolean;
 
+  /** The server provides all output paths
+   * via method buildTarget/outputPaths */
+  outputPathsProvider?: Boolean;
+
   /** Reloading the build state through workspace/reload is supported */
   canReload?: Boolean
 
@@ -896,6 +900,63 @@ export interface ResourcesItem {
   target: BuildTargetIdentifier;
   /** List of resource files. */
   resources: Uri[];
+}
+```
+
+### Output Paths Request
+
+The build target output paths request is sent from the client to the server to
+query for the list of output paths of a given list of build targets.
+
+An output path is a file or directory that contains output files such as build
+artifacts which IDEs may decide to exclude from indexing. The server communicates
+during the initialize handshake whether this method is supported or not.
+
+- method: `buildTarget/outputPaths`
+- params: `OutputPathsParams`
+
+```ts
+export interface OutputPathsParams {
+  targets: BuildTargetIdentifier[];
+}
+```
+
+Response:
+
+- result: `OutputPathsResult`, defined as follows
+
+```ts
+export interface OutputPathsResult {
+  items: OutputPathsItem[];
+}
+
+export interface OutputPathsItem {
+  /** A build target to which output paths item belongs.
+   */
+  target: BuildTargetIdentifier;
+
+  /** Output paths.
+   */
+  outputPaths: OutputPathItem[];
+}
+
+export interface OutputPathItem {
+  /** Either a file or a directory. A directory entry must end with a forward
+   * slash "/" and a directory entry implies that every nested path within the
+   * directory belongs to this output item.
+   */
+  uri: Uri;
+
+  /** Type of file of the output item, such as whether it is file or directory.
+   */
+  kind: OutputPathItemKind;
+}
+
+export namespace OutputPathItemKind {
+  /** The output path item references a normal file.  */
+  export const File: Int = 1;
+  /** The output path item references a directory. */
+  export const Directory: Int = 2;
 }
 ```
 

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jArbitrary.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jArbitrary.scala
@@ -76,6 +76,13 @@ trait Bsp4jArbitrary {
   implicit val arbResourcesItem: Arbitrary[ResourcesItem] = Arbitrary(genResourcesItem)
   implicit val arbResourcesParams: Arbitrary[ResourcesParams] = Arbitrary(genResourcesParams)
   implicit val arbResourcesResult: Arbitrary[ResourcesResult] = Arbitrary(genResourcesResult)
+  implicit val arbOutputPathItem: Arbitrary[OutputPathItem] = Arbitrary(genOutputPathItem)
+  implicit val arbOutputPathItemKind: Arbitrary[OutputPathItemKind] = Arbitrary(
+    genOutputPathItemKind
+  )
+  implicit val arbOutputPathsItem: Arbitrary[OutputPathsItem] = Arbitrary(genOutputPathsItem)
+  implicit val arbOutputPathsParams: Arbitrary[OutputPathsParams] = Arbitrary(genOutputPathsParams)
+  implicit val arbOutputPathsResult: Arbitrary[OutputPathsResult] = Arbitrary(genOutputPathsResult)
   implicit val arbRunParams: Arbitrary[RunParams] = Arbitrary(genRunParams)
   implicit val arbRunProvider: Arbitrary[RunProvider] = Arbitrary(genRunProvider)
   implicit val arbRunResult: Arbitrary[RunResult] = Arbitrary(genRunResult)

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
@@ -461,6 +461,29 @@ trait Bsp4jGenerators {
     items <- genSourcesItem.list
   } yield new SourcesResult(items)
 
+  lazy val genOutputPathItem: Gen[OutputPathItem] = for {
+    uri <- genFileUriString
+    kind <- genOutputPathItemKind
+  } yield new OutputPathItem(uri, kind)
+
+  lazy val genOutputPathItemKind: Gen[OutputPathItemKind] =
+    Gen.oneOf(OutputPathItemKind.values)
+
+  lazy val genOutputPathsItem: Gen[OutputPathsItem] = for {
+    target <- genBuildTargetIdentifier
+    outputPaths <- genOutputPathItem.list
+  } yield {
+    new OutputPathsItem(target, outputPaths)
+  }
+
+  lazy val genOutputPathsParams: Gen[OutputPathsParams] = for {
+    targets <- genBuildTargetIdentifier.list
+  } yield new OutputPathsParams(targets)
+
+  lazy val genOutputPathsResult: Gen[OutputPathsResult] = for {
+    items <- genOutputPathsItem.list
+  } yield new OutputPathsResult(items)
+
   lazy val genStatusCode: Gen[StatusCode] = Gen.oneOf(StatusCode.values)
 
   lazy val genTaskDataKind: Gen[String] = Gen.oneOf(

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jShrinkers.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jShrinkers.scala
@@ -495,6 +495,27 @@ trait Bsp4jShrinkers extends UtilShrinkers {
     shrink(a.getItems).map(new SourcesResult(_))
   }
 
+  implicit def shrinkOutputPathItem: Shrink[OutputPathItem] = Shrink { a =>
+    for {
+      uri <- shrink(a.getUri)
+    } yield new OutputPathItem(uri, a.getKind)
+  }
+
+  implicit def shrinkOutputPathsItem: Shrink[OutputPathsItem] = Shrink { a =>
+    for {
+      target <- shrink(a.getTarget)
+      outputPaths <- shrink(a.getOutputPaths)
+    } yield new OutputPathsItem(target, outputPaths)
+  }
+
+  implicit def shrinkOutputPathsParams: Shrink[OutputPathsParams] = Shrink { a =>
+    shrink(a.getTargets).map(new OutputPathsParams(_))
+  }
+
+  implicit def shrinkOutputPathsResult: Shrink[OutputPathsResult] = Shrink { a =>
+    shrink(a.getItems).map(new OutputPathsResult(_))
+  }
+
   implicit def shrinkTaskFinishParams: Shrink[TaskFinishParams] = Shrink { a =>
     for {
       taskId <- shrink(a.getTaskId)

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
@@ -380,6 +380,32 @@ class HappyMockServer(base: File) extends AbstractMockServer {
       Right(result)
     }
 
+  override def buildTargetOutputPaths(
+      params: OutputPathsParams
+  ): CompletableFuture[OutputPathsResult] =
+    handleRequest {
+      val outputDir1 = new URI(targetId1.getUri).resolve("log/")
+      val item1 = new OutputPathItem(asDirUri(outputDir1), OutputPathItemKind.DIRECTORY)
+      val items1 = new OutputPathsItem(targetId1, List(item1).asJava)
+
+      val outputDir2 = new URI(targetId2.getUri).resolve("target/")
+      val item2 = new OutputPathItem(asDirUri(outputDir2), OutputPathItemKind.DIRECTORY)
+      val items2 = new OutputPathsItem(targetId2, List(item2).asJava)
+
+      val outputDir3 = new URI(targetId3.getUri).resolve("work/")
+      val outputFile1 = new URI(targetId3.getUri).resolve("tmp/file1")
+      val outputFile2 = new URI(targetId3.getUri).resolve("tmp/below/file2")
+      val outputFile3 = new URI(targetId3.getUri).resolve("tmp/file3")
+      val item3Dir = new OutputPathItem(asDirUri(outputDir3), OutputPathItemKind.DIRECTORY)
+      val item31 = new OutputPathItem(outputFile1.toString, OutputPathItemKind.FILE)
+      val item32 = new OutputPathItem(outputFile2.toString, OutputPathItemKind.FILE)
+      val item33 = new OutputPathItem(outputFile3.toString, OutputPathItemKind.FILE)
+      val items3 = new OutputPathsItem(targetId3, List(item3Dir, item31, item32, item33).asJava)
+
+      val result = new OutputPathsResult(List(items1, items2, items3).asJava)
+      Right(result)
+    }
+
   override def buildTargetCompile(params: CompileParams): CompletableFuture[CompileResult] =
     handleRequest {
       val uncompilableTargets = params.getTargets.asScala.filter(targetIdentifier => {

--- a/tests/src/test/scala/tests/MockSuite.scala
+++ b/tests/src/test/scala/tests/MockSuite.scala
@@ -223,6 +223,18 @@ class HappyMockSuite extends AnyFunSuite {
     }
   }
 
+  def assertOutputPaths(server: MockBuildServer, client: TestBuildClient): Unit = {
+    val params = new OutputPathsParams(getBuildTargetIds(server))
+    val result = server.buildTargetOutputPaths(params).get()
+    val items = result.getItems.asScala.toList
+    assert(items.nonEmpty)
+    items.foreach { item =>
+      val sources = item.getOutputPaths.asScala.toList
+      assert(sources.nonEmpty)
+      assert(item.getTarget != null)
+    }
+  }
+
   def assertDependencySources(server: MockBuildServer, client: TestBuildClient): Unit = {
     val params = new DependencySourcesParams(getBuildTargetIds(server))
     val result = server.buildTargetDependencySources(params).get()
@@ -303,6 +315,7 @@ class HappyMockSuite extends AnyFunSuite {
     assertJvmRunEnvironment(server)
     assertSources(server, client)
     assertDependencySources(server, client)
+    assertOutputPaths(server, client)
     assertCompile(server, client)
     assertTest(server, client)
     assertRun(server, client)

--- a/tests/src/test/scala/tests/SerializationPropertySuite.scala
+++ b/tests/src/test/scala/tests/SerializationPropertySuite.scala
@@ -338,6 +338,26 @@ class SerializationPropertySuite extends AnyFunSuite with ScalaCheckPropertyChec
       assertSerializationRoundtrip[bsp4j.SourcesResult, bsp4s.SourcesResult](a)
     }
   }
+  test("OutputPathItem") {
+    forAll { a: bsp4j.OutputPathItem =>
+      assertSerializationRoundtrip[bsp4j.OutputPathItem, bsp4s.OutputPathItem](a)
+    }
+  }
+  test("OutputPathsItem") {
+    forAll { a: bsp4j.OutputPathsItem =>
+      assertSerializationRoundtrip[bsp4j.OutputPathsItem, bsp4s.OutputPathsItem](a)
+    }
+  }
+  test("OutputPathsParams") {
+    forAll { a: bsp4j.OutputPathsParams =>
+      assertSerializationRoundtrip[bsp4j.OutputPathsParams, bsp4s.OutputPathsParams](a)
+    }
+  }
+  test("OutputPathsResult") {
+    forAll { a: bsp4j.OutputPathsResult =>
+      assertSerializationRoundtrip[bsp4j.OutputPathsResult, bsp4s.OutputPathsResult](a)
+    }
+  }
   test("StatusCode") {
     forAll { a: bsp4j.StatusCode =>
       assertSerializationRoundtrip[bsp4j.StatusCode, bsp4s.StatusCode](a)

--- a/tests/src/test/scala/tests/TypoSuite.scala
+++ b/tests/src/test/scala/tests/TypoSuite.scala
@@ -50,6 +50,7 @@ class TypoSuite extends AnyFunSuite {
   val textDocumentIdentifier = new TextDocumentIdentifier("tti")
   val textDocumentIdentifiers: util.List[TextDocumentIdentifier] =
     Collections.singletonList(textDocumentIdentifier)
+  val outputPathUri = "file:///target/"
 
   // Java build client that ignores all notifications.
   val silentJavaClient: BuildClient = new BuildClient {
@@ -150,6 +151,17 @@ class TypoSuite extends AnyFunSuite {
         new ResourcesResult(Collections.singletonList(item))
       }
     }
+    override def buildTargetOutputPaths(
+        params: OutputPathsParams
+    ): CompletableFuture[OutputPathsResult] = {
+      CompletableFuture.completedFuture {
+        val item = new OutputPathsItem(
+          buildTargetUri,
+          Collections.singletonList(new OutputPathItem(outputPathUri, OutputPathItemKind.DIRECTORY))
+        )
+        new OutputPathsResult(Collections.singletonList(item))
+      }
+    }
     override def buildTargetCompile(params: CompileParams): CompletableFuture[CompileResult] = {
       CompletableFuture.completedFuture {
         new CompileResult(StatusCode.OK)
@@ -248,6 +260,7 @@ class TypoSuite extends AnyFunSuite {
       .forwardRequest(s.BuildTarget.dependencyModules)
       .forwardRequest(s.BuildTarget.inverseSources)
       .forwardRequest(s.BuildTarget.resources)
+      .forwardRequest(s.BuildTarget.outputPaths)
       .forwardRequest(s.BuildTarget.compile)
       .forwardRequest(s.BuildTarget.run)
       .forwardRequest(s.BuildTarget.test)
@@ -418,6 +431,9 @@ class TypoSuite extends AnyFunSuite {
           .toScala
         resources <- scala1
           .buildTargetResources(new ResourcesParams(buildTargetUris))
+          .toScala
+        outputPaths <- scala1
+          .buildTargetOutputPaths(new OutputPathsParams(buildTargetUris))
           .toScala
         clean <- scala1
           .buildTargetCleanCache(new CleanCacheParams(buildTargetUris))


### PR DESCRIPTION
This adds `outputDirectory` to BuildTarget to fix #205 