### PR TITLE
Use java-object-diff to compare WorkspaceBuildTargetsResult objects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -134,6 +134,7 @@ lazy val `bsp-testkit` = project
     batScriptExtraDefines += """call :add_java "-Dscript.path=%APP_HOME%\\"""" + executableScriptName.value + ".bat",
     libraryDependencies ++= List(
       "org.scalacheck" %% "scalacheck" % V.scalacheck,
+      "de.danielbechler" % "java-object-diff" % "0.95",
       "org.scala-lang.modules" %% "scala-java8-compat" % V.java8Compat,
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.6.0"
     ),


### PR DESCRIPTION
I have tested this manually by tweaking the values hardcoded in HappyMockServer. The difference report looks like this:

```
[info] Property at path '/targets[BuildTarget [ \ id = BuildTargetIdentifier [ \ uri = "file:/tmp/bsp.MockClientSuite8802115287538715484/target1" \ ] \ displayName = "target 1" \ baseDirectory = "file:/tmp/bsp.MockClientSuite8802115287538715484/target1" \ tags = SeqWrapper ( \ "library" \ ) \ languageIds = SeqWrapper ( \ "scala" \ ) \ dependencies = EmptyList () \ capabilities = BuildTargetCapabilities [ \ canCompile = true \ canTest = false \ canRun = false \ canDebug = false \ ] \ dataKind = "scala" \ data = ScalaBuildTarget [ \ scalaOrganization = "org.scala-lang" \ scalaVersion = "2.12.7" \ scalaBinaryVersion = "2.12" \ platform = JVM \ jars = SeqWrapper ( \ "scala-compiler.jar", \ "scala-reflect.jar", \ "scala-library.jar" \ ) \ jvmBuildTarget = JvmBuildTarget [ \ javaHome = "file:///usr/lib/jvm/java-8-jdk/jre/" \ javaVersion = "1.8" \ ] \ ] \ ]]/data/jvmBuildTarget/javaHome' has changed from [ file:///usr/lib/jvm/java-8-jdk/jre/ ] to [ bar ]
[info] Property at path '/targets[BuildTarget [ \ id = BuildTargetIdentifier [ \ uri = "file:/tmp/bsp.MockClientSuite8802115287538715484/target2" \ ] \ displayName = "target 2" \ baseDirectory = "file:/tmp/bsp.MockClientSuite8802115287538715484/target2" \ tags = SeqWrapper ( \ "test" \ ) \ languageIds = SeqWrapper ( \ "scala" \ ) \ dependencies = SeqWrapper ( \ BuildTargetIdentifier [ \ uri = "file:/tmp/bsp.MockClientSuite8802115287538715484/target1" \ ] \ ) \ capabilities = BuildTargetCapabilities [ \ canCompile = true \ canTest = true \ canRun = false \ canDebug = false \ ] \ dataKind = "jvm" \ data = JvmBuildTarget [ \ javaHome = "file:///usr/lib/jvm/java-8-jdk/jre/" \ javaVersion = "1.8" \ ] \ ]]/data/javaHome' has changed from [ file:///usr/lib/jvm/java-8-jdk/jre/ ] to [ bar ]
[info] Property at path '/targets[BuildTarget [ \ id = BuildTargetIdentifier [ \ uri = "file:/tmp/bsp.MockClientSuite8802115287538715484/target3" \ ] \ displayName = "target 3" \ baseDirectory = "file:/tmp/bsp.MockClientSuite8802115287538715484/target4" \ tags = SeqWrapper ( \ "application" \ ) \ languageIds = SeqWrapper ( \ "scala" \ ) \ dependencies = SeqWrapper ( \ BuildTargetIdentifier [ \ uri = "file:/tmp/bsp.MockClientSuite8802115287538715484/target1" \ ] \ ) \ capabilities = BuildTargetCapabilities [ \ canCompile = true \ canTest = false \ canRun = true \ canDebug = false \ ] \ dataKind = "sbt" \ data = SbtBuildTarget [ \ sbtVersion = "1.0.0" \ autoImports = SeqWrapper ( \ "task-key" \ ) \ scalaBuildTarget = ScalaBuildTarget [ \ scalaOrganization = "org.scala-lang" \ scalaVersion = "2.12.7" \ scalaBinaryVersion = "2.12" \ platform = JVM \ jars = SeqWrapper ( \ "scala-compiler.jar", \ "scala-reflect.jar", \ "scala-library.jar" \ ) \ jvmBuildTarget = JvmBuildTarget [ \ javaHome = "file:///usr/lib/jvm/java-8-jdk/jre/" \ javaVersion = "1.8" \ ] \ ] \ parent = null \ children = SeqWrapper ( \ BuildTargetIdentifier [ \ uri = "file:/tmp/bsp.MockClientSuite8802115287538715484/target3" \ ] \ ) \ ] \ ]]/data/sbtVersion' has changed from [ 1.0.0 ] to [ 1.1.0 ]
[info] Property at path '/targets[BuildTarget [ \ id = BuildTargetIdentifier [ \ uri = "file:/tmp/bsp.MockClientSuite8802115287538715484/target3" \ ] \ displayName = "target 3" \ baseDirectory = "file:/tmp/bsp.MockClientSuite8802115287538715484/target4" \ tags = SeqWrapper ( \ "application" \ ) \ languageIds = SeqWrapper ( \ "scala" \ ) \ dependencies = SeqWrapper ( \ BuildTargetIdentifier [ \ uri = "file:/tmp/bsp.MockClientSuite8802115287538715484/target1" \ ] \ ) \ capabilities = BuildTargetCapabilities [ \ canCompile = true \ canTest = false \ canRun = true \ canDebug = false \ ] \ dataKind = "sbt" \ data = SbtBuildTarget [ \ sbtVersion = "1.0.0" \ autoImports = SeqWrapper ( \ "task-key" \ ) \ scalaBuildTarget = ScalaBuildTarget [ \ scalaOrganization = "org.scala-lang" \ scalaVersion = "2.12.7" \ scalaBinaryVersion = "2.12" \ platform = JVM \ jars = SeqWrapper ( \ "scala-compiler.jar", \ "scala-reflect.jar", \ "scala-library.jar" \ ) \ jvmBuildTarget = JvmBuildTarget [ \ javaHome = "file:///usr/lib/jvm/java-8-jdk/jre/" \ javaVersion = "1.8" \ ] \ ] \ parent = null \ children = SeqWrapper ( \ BuildTargetIdentifier [ \ uri = "file:/tmp/bsp.MockClientSuite8802115287538715484/target3" \ ] \ ) \ ] \ ]]/data/scalaBuildTarget/jvmBuildTarget/javaHome' has changed from [ file:///usr/lib/jvm/java-8-jdk/jre/ ] to [ bar ]
[info] Property at path '/targets[BuildTarget [ \ id = BuildTargetIdentifier [ \ uri = "file:/tmp/bsp.MockClientSuite8802115287538715484/target4" \ ] \ displayName = "target 4" \ baseDirectory = null \ tags = SeqWrapper ( \ "application" \ ) \ languageIds = SeqWrapper ( \ "cpp" \ ) \ dependencies = SeqWrapper () \ capabilities = BuildTargetCapabilities [ \ canCompile = true \ canTest = false \ canRun = true \ canDebug = false \ ] \ dataKind = "cpp" \ data = CppBuildTarget [ \ version = "C++11" \ compiler = "gcc" \ cCompiler = "/usr/bin/gcc" \ cppCompiler = "/usr/bin/g++" \ ] \ ]]/data/compiler' has changed from [ gcc ] to [ gzzcc ]

```