### PR TITLE
feat: add scala test selection request

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -3,5 +3,4 @@
 -Xmx8G
 -XX:ReservedCodeCacheSize=1024m
 -XX:+TieredCompilation
--XX:+CMSClassUnloadingEnabled
 

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/DebugSessionParamsDataKind.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/DebugSessionParamsDataKind.java
@@ -3,5 +3,6 @@ package ch.epfl.scala.bsp4j;
 public final class DebugSessionParamsDataKind {
     public static final String SCALA_MAIN_CLASS = "scala-main-class";
     public static final String SCALA_TEST_SUITES = "scala-test-suites";
+    public static final String SCALA_TEST_SUITES_SELECTION = "scala-test-suites-selection";
     public static final String SCALA_ATTACH_REMOTE = "scala-attach-remote";
 }

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/ScalaExtension.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/ScalaExtension.xtend
@@ -126,3 +126,39 @@ class ScalaMainClass {
     this.jvmOptions = jvmOptions
   }
 }
+
+@JsonRpcData
+class ScalaTestSuites {
+  @NonNull List<ScalaTestSuiteSelection> suites
+  /**
+   * Additional jvmOptions which will be passed to the forked JVM
+   */
+  @NonNull List<String> jvmOptions
+  /**
+   * Enviroment variables should be an array of strings in format KEY=VALUE
+   */
+  @NonNull List<String> environmentVariables
+  new(@NonNull List<ScalaTestSuiteSelection> suites, @NonNull List<String> jvmOptions, @NonNull List<String> environmentVariables) {
+    this.suites = suites
+    this.jvmOptions = jvmOptions
+    this.environmentVariables = environmentVariables
+  }
+}
+
+@JsonRpcData
+class ScalaTestSuiteSelection {
+  /**
+    * Fully qualified name of the test suite class
+    */
+  @NonNull String className
+  /**
+    * List of tests which should be run within this test suite.
+    * Empty collection means that all of them are supposed to be executed.
+    */
+  @NonNull List<String> tests
+
+  new(@NonNull String className, @NonNull List<String> tests) {
+    this.className = className
+    this.tests = tests
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestSuiteSelection.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestSuiteSelection.java
@@ -1,0 +1,103 @@
+package ch.epfl.scala.bsp4j;
+
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ScalaTestSuiteSelection {
+  /**
+   * Fully qualified name of the test suite class
+   */
+  @NonNull
+  private String className;
+  
+  /**
+   * List of tests which should be run within this test suite.
+   * Empty collection means that all of them are supposed to be executed.
+   */
+  @NonNull
+  private List<String> tests;
+  
+  public ScalaTestSuiteSelection(@NonNull final String className, @NonNull final List<String> tests) {
+    this.className = className;
+    this.tests = tests;
+  }
+  
+  /**
+   * Fully qualified name of the test suite class
+   */
+  @Pure
+  @NonNull
+  public String getClassName() {
+    return this.className;
+  }
+  
+  /**
+   * Fully qualified name of the test suite class
+   */
+  public void setClassName(@NonNull final String className) {
+    this.className = Preconditions.checkNotNull(className, "className");
+  }
+  
+  /**
+   * List of tests which should be run within this test suite.
+   * Empty collection means that all of them are supposed to be executed.
+   */
+  @Pure
+  @NonNull
+  public List<String> getTests() {
+    return this.tests;
+  }
+  
+  /**
+   * List of tests which should be run within this test suite.
+   * Empty collection means that all of them are supposed to be executed.
+   */
+  public void setTests(@NonNull final List<String> tests) {
+    this.tests = Preconditions.checkNotNull(tests, "tests");
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("className", this.className);
+    b.add("tests", this.tests);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ScalaTestSuiteSelection other = (ScalaTestSuiteSelection) obj;
+    if (this.className == null) {
+      if (other.className != null)
+        return false;
+    } else if (!this.className.equals(other.className))
+      return false;
+    if (this.tests == null) {
+      if (other.tests != null)
+        return false;
+    } else if (!this.tests.equals(other.tests))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.className== null) ? 0 : this.className.hashCode());
+    return prime * result + ((this.tests== null) ? 0 : this.tests.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestSuites.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestSuites.java
@@ -1,0 +1,121 @@
+package ch.epfl.scala.bsp4j;
+
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ScalaTestSuites {
+  @NonNull
+  private List<ScalaTestSuiteSelection> suites;
+  
+  /**
+   * Additional jvmOptions which will be passed to the forked JVM
+   */
+  @NonNull
+  private List<String> jvmOptions;
+  
+  /**
+   * Enviroment variables should be an array of strings in format KEY=VALUE
+   */
+  @NonNull
+  private List<String> environmentVariables;
+  
+  public ScalaTestSuites(@NonNull final List<ScalaTestSuiteSelection> suites, @NonNull final List<String> jvmOptions, @NonNull final List<String> environmentVariables) {
+    this.suites = suites;
+    this.jvmOptions = jvmOptions;
+    this.environmentVariables = environmentVariables;
+  }
+  
+  @Pure
+  @NonNull
+  public List<ScalaTestSuiteSelection> getSuites() {
+    return this.suites;
+  }
+  
+  public void setSuites(@NonNull final List<ScalaTestSuiteSelection> suites) {
+    this.suites = Preconditions.checkNotNull(suites, "suites");
+  }
+  
+  /**
+   * Additional jvmOptions which will be passed to the forked JVM
+   */
+  @Pure
+  @NonNull
+  public List<String> getJvmOptions() {
+    return this.jvmOptions;
+  }
+  
+  /**
+   * Additional jvmOptions which will be passed to the forked JVM
+   */
+  public void setJvmOptions(@NonNull final List<String> jvmOptions) {
+    this.jvmOptions = Preconditions.checkNotNull(jvmOptions, "jvmOptions");
+  }
+  
+  /**
+   * Enviroment variables should be an array of strings in format KEY=VALUE
+   */
+  @Pure
+  @NonNull
+  public List<String> getEnvironmentVariables() {
+    return this.environmentVariables;
+  }
+  
+  /**
+   * Enviroment variables should be an array of strings in format KEY=VALUE
+   */
+  public void setEnvironmentVariables(@NonNull final List<String> environmentVariables) {
+    this.environmentVariables = Preconditions.checkNotNull(environmentVariables, "environmentVariables");
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("suites", this.suites);
+    b.add("jvmOptions", this.jvmOptions);
+    b.add("environmentVariables", this.environmentVariables);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ScalaTestSuites other = (ScalaTestSuites) obj;
+    if (this.suites == null) {
+      if (other.suites != null)
+        return false;
+    } else if (!this.suites.equals(other.suites))
+      return false;
+    if (this.jvmOptions == null) {
+      if (other.jvmOptions != null)
+        return false;
+    } else if (!this.jvmOptions.equals(other.jvmOptions))
+      return false;
+    if (this.environmentVariables == null) {
+      if (other.environmentVariables != null)
+        return false;
+    } else if (!this.environmentVariables.equals(other.environmentVariables))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.suites== null) ? 0 : this.suites.hashCode());
+    result = prime * result + ((this.jvmOptions== null) ? 0 : this.jvmOptions.hashCode());
+    return prime * result + ((this.environmentVariables== null) ? 0 : this.environmentVariables.hashCode());
+  }
+}

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -1130,6 +1130,23 @@ object ScalaMainClassesResult {
     JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
+case class ScalaTestSuites(
+    classes: List[ScalaTestSuiteSelection],
+    jvmOptions: List[String],
+    environmentVariables: List[String],
+)
+object ScalaTestSuites {
+  implicit val codec: JsonValueCodec[ScalaTestSuites] = JsonCodecMaker.makeWithRequiredCollectionFields
+}
+
+case class ScalaTestSuiteSelection(
+    className: String,
+    tests: List[String]
+)
+object ScalaTestSuiteSelection {
+  implicit val codec: JsonValueCodec[ScalaTestSuiteSelection] = JsonCodecMaker.makeWithRequiredCollectionFields
+}
+
 final case class SbtBuildTarget(
     sbtVersion: String,
     autoImports: List[String],
@@ -1170,6 +1187,7 @@ object DebugSessionParams {
 object DebugSessionParamsDataKind {
   val ScalaMainClass = "scala-main-class"
   val ScalaTestSuites = "scala-test-suites"
+  val ScalaTestSuitesSelection = "scala-test-suites-selection"
   val ScalaAttachRemote = "scala-attach-remote"
 }
 


### PR DESCRIPTION
implements #249

There are only two scala build servers that implement debugging: bloop and sbt (I checked also mill and bazel-bsp). If this new kind is implemented in both of them then it'll be safe to add the new kind without any capability.
Progress with implementation:
- [x] bloop (need changes)
- [x] sbt - https://github.com/scalacenter/scala-debug-adapter/pull/198
- [x] handling it in Metals - https://github.com/scalameta/metals/pull/3678