### PR TITLE
Small nitpicks regarding JVM environment requests

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/JvmExtension.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/JvmExtension.xtend
@@ -18,8 +18,16 @@ class JvmBuildTarget {
 @JsonRpcData
 class JvmTestEnvironmentParams {
   @NonNull List<BuildTargetIdentifier> targets
+  String originId
+
   new(@NonNull List<BuildTargetIdentifier> targets) {
     this.targets = targets
+    this.originId = null
+  }
+
+  new(@NonNull List<BuildTargetIdentifier> targets, String originId) {
+    this.targets = targets
+    this.originId = originId
   }
 }
 
@@ -52,8 +60,16 @@ class JvmTestEnvironmentResult {
 @JsonRpcData
 class JvmRunEnvironmentParams {
   @NonNull List<BuildTargetIdentifier> targets
+  String originId
+
   new(@NonNull List<BuildTargetIdentifier> targets) {
     this.targets = targets
+    this.originId = null
+  }
+
+  new(@NonNull List<BuildTargetIdentifier> targets, String originId) {
+    this.targets = targets
+    this.originId = originId
   }
 }
 

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JvmRunEnvironmentParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JvmRunEnvironmentParams.java
@@ -11,8 +11,16 @@ public class JvmRunEnvironmentParams {
   @NonNull
   private List<BuildTargetIdentifier> targets;
   
+  private String originId;
+  
   public JvmRunEnvironmentParams(@NonNull final List<BuildTargetIdentifier> targets) {
     this.targets = targets;
+    this.originId = null;
+  }
+  
+  public JvmRunEnvironmentParams(@NonNull final List<BuildTargetIdentifier> targets, final String originId) {
+    this.targets = targets;
+    this.originId = originId;
   }
   
   @Pure
@@ -25,11 +33,21 @@ public class JvmRunEnvironmentParams {
     this.targets = Preconditions.checkNotNull(targets, "targets");
   }
   
+  @Pure
+  public String getOriginId() {
+    return this.originId;
+  }
+  
+  public void setOriginId(final String originId) {
+    this.originId = originId;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("targets", this.targets);
+    b.add("originId", this.originId);
     return b.toString();
   }
   
@@ -48,12 +66,20 @@ public class JvmRunEnvironmentParams {
         return false;
     } else if (!this.targets.equals(other.targets))
       return false;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
+      return false;
     return true;
   }
   
   @Override
   @Pure
   public int hashCode() {
-    return 31 * 1 + ((this.targets== null) ? 0 : this.targets.hashCode());
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.targets== null) ? 0 : this.targets.hashCode());
+    return prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
   }
 }

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JvmTestEnvironmentParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/JvmTestEnvironmentParams.java
@@ -11,8 +11,16 @@ public class JvmTestEnvironmentParams {
   @NonNull
   private List<BuildTargetIdentifier> targets;
   
+  private String originId;
+  
   public JvmTestEnvironmentParams(@NonNull final List<BuildTargetIdentifier> targets) {
     this.targets = targets;
+    this.originId = null;
+  }
+  
+  public JvmTestEnvironmentParams(@NonNull final List<BuildTargetIdentifier> targets, final String originId) {
+    this.targets = targets;
+    this.originId = originId;
   }
   
   @Pure
@@ -25,11 +33,21 @@ public class JvmTestEnvironmentParams {
     this.targets = Preconditions.checkNotNull(targets, "targets");
   }
   
+  @Pure
+  public String getOriginId() {
+    return this.originId;
+  }
+  
+  public void setOriginId(final String originId) {
+    this.originId = originId;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("targets", this.targets);
+    b.add("originId", this.originId);
     return b.toString();
   }
   
@@ -48,12 +66,20 @@ public class JvmTestEnvironmentParams {
         return false;
     } else if (!this.targets.equals(other.targets))
       return false;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
+      return false;
     return true;
   }
   
   @Override
   @Pure
   public int hashCode() {
-    return 31 * 1 + ((this.targets== null) ? 0 : this.targets.hashCode());
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.targets== null) ? 0 : this.targets.hashCode());
+    return prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
   }
 }

--- a/docs/extensions/jvm.md
+++ b/docs/extensions/jvm.md
@@ -58,12 +58,12 @@ export interface JvmEnvironmentItem{
     target: BuildTargetIdentifier;
     classpath: Uri[];
     jvmOptions: String[];
+    workingDirectory: String;
+    environmentVariables: Map<String, String>;
 }
 
 export interface JvmTestEnvironmentResult{
     items: JvmEnvironmentItem[];
-    workingDirectory: String;
-    environmentVariables: Map<String, String>;
 }
 ```
 
@@ -93,11 +93,11 @@ export interface JvmEnvironmentItem{
     target: BuildTargetIdentifier;
     classpath: Uri[];
     jvmOptions: String[];
+    workingDirectory: String;
+    environmentVariables: Map<String, String>;
 }
 
 export interface JvmRunEnvironmentResult{
     items: JvmEnvironmentItem[];
-    workingDirectory: String;
-    environmentVariables: Map<String, String>;
 }
 ```


### PR DESCRIPTION
Current documentation was outdated and it didn't reflect the actual shape of requests. Additionally, java classes lacked `originId` field - I added it with an additional constructor to not break compatibility.

For the reference this is what Scala classes looks like:
```scala
final case class JvmTestEnvironmentParams(
    targets: List[BuildTargetIdentifier],
    originId: Option[String]
)

final case class JvmEnvironmentItem(
    target: BuildTargetIdentifier,
    classpath: List[String],
    jvmOptions: List[String],
    workingDirectory: String,
    environmentVariables: Map[String, String]
)

final case class JvmTestEnvironmentResult(
    items: List[JvmEnvironmentItem]
)
```