### PR TITLE
feat: add `debugSession/start` request to `the BuildServer`

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
@@ -46,6 +46,9 @@ public interface BuildServer {
     @JsonRequest("buildTarget/run")
     CompletableFuture<RunResult> buildTargetRun(RunParams params);
 
+    @JsonRequest("debugSession/start")
+    CompletableFuture<DebugSessionAddress> debugSessionStart(DebugSessionParams params);
+
     @JsonRequest("buildTarget/cleanCache")
     CompletableFuture<CleanCacheResult> buildTargetCleanCache(CleanCacheParams params);
 

--- a/docs/bindings/java.md
+++ b/docs/bindings/java.md
@@ -170,6 +170,7 @@ class MyBuildServer extends BuildServer {
   def buildTargetRun(params: RunParams): CompletableFuture[RunResult] = ???
   def buildTargetSources(params: SourcesParams): CompletableFuture[SourcesResult] = ???
   def buildTargetTest(params: TestParams): CompletableFuture[TestResult] = ???
+  def debugSessionStart(params: DebugSessionParams): CompletableFuture[DebugSessionAddress] = ???
   def onBuildExit(): Unit = ???
   def onBuildInitialized(): Unit = ???
   def workspaceBuildTargets(): CompletableFuture[WorkspaceBuildTargetsResult] = ???

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
@@ -493,6 +493,13 @@ class HappyMockServer(base: File) extends AbstractMockServer {
     Right(result)
   }
 
+  override def debugSessionStart(
+      params: DebugSessionParams
+  ): CompletableFuture[DebugSessionAddress] =
+    handleRequest {
+      Right(new DebugSessionAddress("tcp://127.0.0.1:51379"))
+    }
+
   override def buildTargetCleanCache(
       params: CleanCacheParams
   ): CompletableFuture[CleanCacheResult] =

--- a/tests/src/test/scala/tests/TypoSuite.scala
+++ b/tests/src/test/scala/tests/TypoSuite.scala
@@ -165,6 +165,14 @@ class TypoSuite extends AnyFunSuite {
         new RunResult(StatusCode.ERROR)
       }
     }
+
+    override def debugSessionStart(
+        params: DebugSessionParams
+    ): CompletableFuture[DebugSessionAddress] =
+      CompletableFuture.completedFuture {
+        new DebugSessionAddress("tcp://127.0.0.1:51379")
+      }
+
     override def buildTargetCleanCache(
         params: CleanCacheParams
     ): CompletableFuture[CleanCacheResult] = {


### PR DESCRIPTION
This request is specified at https://build-server-protocol.github.io/docs/specification.html#debug-request