### PR TITLE
fix: align DiagnosticRelatedInformation with the LSP spec

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -250,7 +250,7 @@ class Diagnostic {
   String code
   String source
   @NonNull String message
-  DiagnosticRelatedInformation relatedInformation
+  List<DiagnosticRelatedInformation> relatedInformation
   new(@NonNull Range range, @NonNull String message) {
     this.range = range
     this.message = message

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Diagnostic.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Diagnostic.java
@@ -1,5 +1,6 @@
 package ch.epfl.scala.bsp4j;
 
+import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -19,7 +20,7 @@ public class Diagnostic {
   @NonNull
   private String message;
   
-  private DiagnosticRelatedInformation relatedInformation;
+  private List<DiagnosticRelatedInformation> relatedInformation;
   
   public Diagnostic(@NonNull final Range range, @NonNull final String message) {
     this.range = range;
@@ -74,11 +75,11 @@ public class Diagnostic {
   }
   
   @Pure
-  public DiagnosticRelatedInformation getRelatedInformation() {
+  public List<DiagnosticRelatedInformation> getRelatedInformation() {
     return this.relatedInformation;
   }
   
-  public void setRelatedInformation(final DiagnosticRelatedInformation relatedInformation) {
+  public void setRelatedInformation(final List<DiagnosticRelatedInformation> relatedInformation) {
     this.relatedInformation = relatedInformation;
   }
   

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -365,7 +365,7 @@ final case class Diagnostic(
     code: Option[String],
     source: Option[String],
     message: String,
-    relatedInformation: Option[DiagnosticRelatedInformation]
+    relatedInformation: Option[List[DiagnosticRelatedInformation]]
 )
 
 object Diagnostic {

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
@@ -184,7 +184,7 @@ trait Bsp4jGenerators {
     severity <- genDiagnosticSeverity.nullable
     code <- arbitrary[String].nullable
     source <- arbitrary[String].nullable
-    relatedInformation <- genDiagnosticRelatedInformation.nullable
+    relatedInformation <- genDiagnosticRelatedInformation.list.nullable
   } yield {
     val diagnostic = new Diagnostic(range, message)
     diagnostic.setSeverity(severity)

--- a/tests/src/test/scala/tests/SerializationSuite.scala
+++ b/tests/src/test/scala/tests/SerializationSuite.scala
@@ -59,8 +59,19 @@ class SerializationSuite extends AnyFunSuite {
     val textDocument = new URI("text.document")
 
     val range1 = bsp4s.Range(bsp4s.Position(1, 1), bsp4s.Position(1, 12))
+    val location = bsp4s.Location(bsp4s.Uri(new URI("other")), range1)
+
+    val relatedInformation = bsp4s.DiagnosticRelatedInformation(location, "message")
+
     val diagnostic1 =
-      bsp4s.Diagnostic(range1, Some(bsp4s.DiagnosticSeverity.Error), None, None, "message", None)
+      bsp4s.Diagnostic(
+        range1,
+        Some(bsp4s.DiagnosticSeverity.Error),
+        None,
+        None,
+        "message",
+        Some(List(relatedInformation))
+      )
 
     val bsp4sValue = bsp4s.PublishDiagnosticsParams(
       bsp4s.TextDocumentIdentifier(bsp4s.Uri(textDocument)),


### PR DESCRIPTION
Previously this was a single DiagnosticRelatedInformation that was
possible to be attached to a diagnostic. This change aligns it with the
[LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic)
making this a `List[DiagnosticRelatedInformation]` instead.


Partly addresses #319 