### PR TITLE
Refactored some tests to make use of the java-object-diff library.

### DIFF
--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -1135,10 +1135,11 @@ object ScalaMainClassesResult {
 case class ScalaTestSuites(
     classes: List[ScalaTestSuiteSelection],
     jvmOptions: List[String],
-    environmentVariables: List[String],
+    environmentVariables: List[String]
 )
 object ScalaTestSuites {
-  implicit val codec: JsonValueCodec[ScalaTestSuites] = JsonCodecMaker.makeWithRequiredCollectionFields
+  implicit val codec: JsonValueCodec[ScalaTestSuites] =
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 case class ScalaTestSuiteSelection(
@@ -1146,7 +1147,8 @@ case class ScalaTestSuiteSelection(
     tests: List[String]
 )
 object ScalaTestSuiteSelection {
-  implicit val codec: JsonValueCodec[ScalaTestSuiteSelection] = JsonCodecMaker.makeWithRequiredCollectionFields
+  implicit val codec: JsonValueCodec[ScalaTestSuiteSelection] =
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class SbtBuildTarget(

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/TestClient.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/TestClient.scala
@@ -495,11 +495,9 @@ class TestClient(
           compareBuildTargets(expectedWorkspaceBuildTargetsResult, workspaceBuildTargetsResult)
         assert(
           !testTargetsDiff.hasChanges,
-          s"Workspace Build Targets did not match!\n${
-              val visitor = new ToMapPrintingVisitor(workspaceBuildTargetsResult, expectedWorkspaceBuildTargetsResult)
-              testTargetsDiff.visit(visitor)
-              visitor.getMessagesAsString
-            }"
+          s"Workspace Build Targets did not match!\n${val visitor = new ToMapPrintingVisitor(workspaceBuildTargetsResult, expectedWorkspaceBuildTargetsResult)
+            testTargetsDiff.visit(visitor)
+            visitor.getMessagesAsString }"
         )
         workspaceBuildTargetsResult
       })
@@ -635,11 +633,9 @@ class TestClient(
         val testItemsDiff = testJvmItems(jvmItems, expectedResult.getItems)
         assert(
           !testItemsDiff.hasChanges,
-          s"JVM Run Environment Items did not match!\n${
-            val visitor = new ToMapPrintingVisitor(jvmItems, expectedResult.getItems)
+          s"JVM Run Environment Items did not match!\n${val visitor = new ToMapPrintingVisitor(jvmItems, expectedResult.getItems)
             testItemsDiff.visit(visitor)
-            visitor.getMessagesAsString
-          }"
+            visitor.getMessagesAsString }"
         )
       })
   }
@@ -663,11 +659,9 @@ class TestClient(
         val testItemsDiff = testJvmItems(jvmItems, expectedResult.getItems)
         assert(
           !testItemsDiff.hasChanges,
-          s"JVM Test Environment Items did not match!\n${
-            val visitor = new ToMapPrintingVisitor(jvmItems, expectedResult.getItems)
+          s"JVM Test Environment Items did not match!\n${val visitor = new ToMapPrintingVisitor(jvmItems, expectedResult.getItems)
             testItemsDiff.visit(visitor)
-            visitor.getMessagesAsString
-          }"
+            visitor.getMessagesAsString }"
         )
       })
   }
@@ -687,7 +681,9 @@ class TestClient(
       .identity()
       .ofCollectionItems(NodePath.withRoot())
       .via((working: Any, base: Any) => {
-        working.asInstanceOf[JvmEnvironmentItem].getTarget == base.asInstanceOf[JvmEnvironmentItem].getTarget
+        working
+          .asInstanceOf[JvmEnvironmentItem]
+          .getTarget == base.asInstanceOf[JvmEnvironmentItem].getTarget
       })
       .and()
       .build()
@@ -709,18 +705,18 @@ class TestClient(
           .identity()
           .ofCollectionItems(NodePath.withRoot())
           .via((working: Any, base: Any) => {
-            working.asInstanceOf[JavacOptionsItem].getTarget == base.asInstanceOf[JavacOptionsItem].getTarget
+            working
+              .asInstanceOf[JavacOptionsItem]
+              .getTarget == base.asInstanceOf[JavacOptionsItem].getTarget
           })
           .and()
           .build()
           .compare(javacOptionsItems, expectedResult.getItems)
         assert(
           diff.hasChanges,
-          s"Javac Options Items did not match!\n${
-            val visitor = new ToMapPrintingVisitor(javacOptionsItems, expectedResult.getItems)
+          s"Javac Options Items did not match!\n${val visitor = new ToMapPrintingVisitor(javacOptionsItems, expectedResult.getItems)
             diff.visit(visitor)
-            visitor.getMessagesAsString
-          }"
+            visitor.getMessagesAsString }"
         )
       })
   }
@@ -746,18 +742,18 @@ class TestClient(
           .identity()
           .ofCollectionItems(NodePath.withRoot())
           .via((working: Any, base: Any) => {
-            working.asInstanceOf[ScalacOptionsItem].getTarget == base.asInstanceOf[ScalacOptionsItem].getTarget
+            working
+              .asInstanceOf[ScalacOptionsItem]
+              .getTarget == base.asInstanceOf[ScalacOptionsItem].getTarget
           })
           .and()
           .build()
           .compare(scalacOptionsItems, expectedResult.getItems)
         assert(
           diff.hasChanges,
-          s"Scalac Options Items did not match!\n${
-            val visitor = new ToMapPrintingVisitor(scalacOptionsItems, expectedResult.getItems)
+          s"Scalac Options Items did not match!\n${val visitor = new ToMapPrintingVisitor(scalacOptionsItems, expectedResult.getItems)
             diff.visit(visitor)
-            visitor.getMessagesAsString
-          }"
+            visitor.getMessagesAsString }"
         )
       })
   }

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/TestClient.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/TestClient.scala
@@ -632,10 +632,14 @@ class TestClient(
       .toScala
       .map(result => result.getItems)
       .map(jvmItems => {
-        val testItems = testJvmItems(jvmItems, expectedResult.getItems)
+        val testItemsDiff = testJvmItems(jvmItems, expectedResult.getItems)
         assert(
-          testItems,
-          s"JVM Run Environment Items did not match! Expected: $expectedResult, got $jvmItems"
+          !testItemsDiff.hasChanges,
+          s"JVM Run Environment Items did not match!\n${
+            val visitor = new ToMapPrintingVisitor(jvmItems, expectedResult.getItems)
+            testItemsDiff.visit(visitor)
+            visitor.getMessagesAsString
+          }"
         )
       })
   }
@@ -656,10 +660,14 @@ class TestClient(
       .toScala
       .map(result => result.getItems)
       .map(jvmItems => {
-        val testItems = testJvmItems(jvmItems, expectedResult.getItems)
+        val testItemsDiff = testJvmItems(jvmItems, expectedResult.getItems)
         assert(
-          testItems,
-          s"JVM Test Environment Items did not match! Expected: $expectedResult, got $jvmItems"
+          !testItemsDiff.hasChanges,
+          s"JVM Test Environment Items did not match!\n${
+            val visitor = new ToMapPrintingVisitor(jvmItems, expectedResult.getItems)
+            testItemsDiff.visit(visitor)
+            visitor.getMessagesAsString
+          }"
         )
       })
   }
@@ -673,31 +681,17 @@ class TestClient(
   private def testJvmItems(
       items: java.util.List[JvmEnvironmentItem],
       expectedItems: java.util.List[JvmEnvironmentItem]
-  ) = {
-    items.forall { item =>
-      expectedItems.exists(expectedItem =>
-        testExpectedEnvVars(expectedItem, item) &&
-          item.getTarget == expectedItem.getTarget &&
-          testExpectedClasspath(expectedItem.getClasspath, item.getClasspath) &&
-          item.getJvmOptions == expectedItem.getJvmOptions
-      )
-    }
-  }
-
-  private def testExpectedEnvVars(expectedItem: JvmEnvironmentItem, item: JvmEnvironmentItem) = {
-    expectedItem.getEnvironmentVariables
-      .entrySet()
-      .forall(entry =>
-        item.getEnvironmentVariables.containsKey(entry.getKey) && item.getEnvironmentVariables
-          .get(entry.getKey) == entry.getValue
-      )
-  }
-
-  private def testExpectedClasspath(
-      expectedClasspath: java.util.List[String],
-      classpath: java.util.List[String]
-  ) = {
-    expectedClasspath.forall(expectedUrl => classpath.exists(url => url.contains(expectedUrl)))
+  ): DiffNode = {
+    ObjectDifferBuilder
+      .startBuilding()
+      .identity()
+      .ofCollectionItems(NodePath.withRoot())
+      .via((working: Any, base: Any) => {
+        working.asInstanceOf[JvmEnvironmentItem].getTarget == base.asInstanceOf[JvmEnvironmentItem].getTarget
+      })
+      .and()
+      .build()
+      .compare(items, expectedItems)
   }
 
   def testJavacOptions(
@@ -709,18 +703,24 @@ class TestClient(
       .buildTargetJavacOptions(params)
       .toScala
       .map(result => result.getItems)
-      .map(jvmItems => {
-        val itemsTest = jvmItems.forall { item =>
-          expectedResult.getItems.exists(expectedItem =>
-            testExpectedClasspath(expectedItem.getClasspath, item.getClasspath) &&
-              item.getClassDirectory.contains(expectedItem.getClassDirectory) &&
-              item.getTarget == expectedItem.getTarget &&
-              item.getOptions == expectedItem.getOptions
-          )
-        }
+      .map(javacOptionsItems => {
+        val diff = ObjectDifferBuilder
+          .startBuilding()
+          .identity()
+          .ofCollectionItems(NodePath.withRoot())
+          .via((working: Any, base: Any) => {
+            working.asInstanceOf[JavacOptionsItem].getTarget == base.asInstanceOf[JavacOptionsItem].getTarget
+          })
+          .and()
+          .build()
+          .compare(javacOptionsItems, expectedResult.getItems)
         assert(
-          itemsTest,
-          s"Javac Options Items did not match! Expected: $expectedResult, got $jvmItems"
+          diff.hasChanges,
+          s"Javac Options Items did not match!\n${
+            val visitor = new ToMapPrintingVisitor(javacOptionsItems, expectedResult.getItems)
+            diff.visit(visitor)
+            visitor.getMessagesAsString
+          }"
         )
       })
   }
@@ -740,18 +740,24 @@ class TestClient(
       .buildTargetScalacOptions(params)
       .toScala
       .map(result => result.getItems)
-      .map(scalacItems => {
-        val itemsTest = scalacItems.forall { item =>
-          expectedResult.getItems.exists(expectedItem =>
-            testExpectedClasspath(expectedItem.getClasspath, item.getClasspath) &&
-              item.getClassDirectory.contains(expectedItem.getClassDirectory) &&
-              item.getTarget == expectedItem.getTarget &&
-              item.getOptions == expectedItem.getOptions
-          )
-        }
+      .map(scalacOptionsItems => {
+        val diff = ObjectDifferBuilder
+          .startBuilding()
+          .identity()
+          .ofCollectionItems(NodePath.withRoot())
+          .via((working: Any, base: Any) => {
+            working.asInstanceOf[ScalacOptionsItem].getTarget == base.asInstanceOf[ScalacOptionsItem].getTarget
+          })
+          .and()
+          .build()
+          .compare(scalacOptionsItems, expectedResult.getItems)
         assert(
-          itemsTest,
-          s"Scalac Environment Items did not match! Expected: $expectedResult, got $scalacItems"
+          diff.hasChanges,
+          s"Scalac Options Items did not match!\n${
+            val visitor = new ToMapPrintingVisitor(scalacOptionsItems, expectedResult.getItems)
+            diff.visit(visitor)
+            visitor.getMessagesAsString
+          }"
         )
       })
   }

--- a/tests/src/test/scala/tests/MockClientSuite.scala
+++ b/tests/src/test/scala/tests/MockClientSuite.scala
@@ -279,10 +279,10 @@ class MockClientSuite extends AnyFunSuite {
     client.testCompareWorkspaceTargetsResults(workspaceBuildTargetsResult)
   }
 
-  private lazy val environmentItem = {
-    val classpath = List("scala-library").asJava
+  private def environmentItem(testing: Boolean) = {
+    val classpath = List("scala-library.jar").asJava
     val jvmOptions = List("-Xms256m").asJava
-    val environmentVariables = Map("A" -> "a").asJava
+    val environmentVariables = Map("A" -> "a", "TESTING" -> testing.toString).asJava
     val workdir = "/tmp"
     val item1 = new JvmEnvironmentItem(
       targetId1,
@@ -297,14 +297,14 @@ class MockClientSuite extends AnyFunSuite {
   test("Jvm Run Environment") {
     client.testJvmRunEnvironment(
       new JvmRunEnvironmentParams(Collections.emptyList()),
-      new JvmRunEnvironmentResult(environmentItem)
+      new JvmRunEnvironmentResult(environmentItem(testing = false))
     )
   }
 
   test("Jvm Test Environment") {
     client.testJvmTestEnvironment(
       new JvmTestEnvironmentParams(Collections.emptyList()),
-      new JvmTestEnvironmentResult(environmentItem)
+      new JvmTestEnvironmentResult(environmentItem(testing = true))
     )
   }
 


### PR DESCRIPTION
Before:
```
[info]   Cause: java.lang.AssertionError: assertion failed: JVM Run Environment Items did not match! Expected: JvmRunEnvironmentResult [
[info]   items = SeqWrapper (
[info]     JvmEnvironmentItem [
[info]       target = BuildTargetIdentifier [
[info]         uri = "file:/tmp/bsp.MockClientSuite17070543597305035972/target1"
[info]       ]
[info]       classpath = SeqWrapper (
[info]         "scala-library.jar"
[info]       )
[info]       jvmOptions = SeqWrapper (
[info]         "-Xms256m"
[info]       )
[info]       workingDirectory = "/tmp"
[info]       environmentVariables = {A=a, TESTING=true}
[info]     ]
[info]   )
[info] ], got [JvmEnvironmentItem [
[info]   target = BuildTargetIdentifier [
[info]     uri = "file:/tmp/bsp.MockClientSuite17070543597305035972/target1"
[info]   ]
[info]   classpath = ArrayList (
[info]     "scala-library.jar"
[info]   )
[info]   jvmOptions = ArrayList (
[info]     "-Xms256m"
[info]   )
[info]   workingDirectory = "/tmp"
[info]   environmentVariables = {A=a, TESTING=false}
[info] ]]
[info]   at scala.Predef$.assert(Predef.scala:279)
```

After:
```
[info]   Cause: java.lang.AssertionError: assertion failed: JVM Run Environment Items did not match!
[info] Property at path '/[JvmEnvironmentItem [ \ target = BuildTargetIdentifier [ \ uri = "file:/tmp/bsp.MockClientSuite10447926668607213956/target1" \ ] \ classpath = SeqWrapper ( \ "scala-library.jar" \ ) \ jvmOptions = SeqWrapper ( \ "-Xms256m" \ ) \ workingDirectory = "/tmp" \ environmentVariables = {A=a, TESTING=true} \ ]]/environmentVariables{TESTING}' has changed from [ true ] to [ false ]
[info]   at scala.Predef$.assert(Predef.scala:279)
```