### PR TITLE
Fixed broken tests and refactored some more tests.

### DIFF
--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/TestClient.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/client/TestClient.scala
@@ -713,7 +713,7 @@ class TestClient(
           .build()
           .compare(javacOptionsItems, expectedResult.getItems)
         assert(
-          diff.hasChanges,
+          !diff.hasChanges,
           s"Javac Options Items did not match!\n${val visitor = new ToMapPrintingVisitor(javacOptionsItems, expectedResult.getItems)
             diff.visit(visitor)
             visitor.getMessagesAsString }"
@@ -750,7 +750,7 @@ class TestClient(
           .build()
           .compare(scalacOptionsItems, expectedResult.getItems)
         assert(
-          diff.hasChanges,
+          !diff.hasChanges,
           s"Scalac Options Items did not match!\n${val visitor = new ToMapPrintingVisitor(scalacOptionsItems, expectedResult.getItems)
             diff.visit(visitor)
             visitor.getMessagesAsString }"
@@ -773,13 +773,15 @@ class TestClient(
       .buildTargetCppOptions(params)
       .toScala
       .map(result => result.getItems)
-      .map(cppItems => {
-        val itemsTest = cppItems.forall { item =>
-          expectedResult.getItems.contains(item)
-        }
+      .map(cppOptionsItems => {
+        val diff = ObjectDifferBuilder
+          .buildDefault()
+          .compare(cppOptionsItems, expectedResult.getItems)
         assert(
-          itemsTest,
-          s"Cpp Environment Items did not match! Expected: $expectedResult, got $cppItems"
+          !diff.hasChanges,
+          s"Cpp Options Items did not match!\n${val visitor = new ToMapPrintingVisitor(cppOptionsItems, expectedResult.getItems)
+            diff.visit(visitor)
+            visitor.getMessagesAsString }"
         )
       })
   }
@@ -800,12 +802,14 @@ class TestClient(
       .toScala
       .map(result => result.getItems)
       .map(mainItems => {
-        val itemsTest = mainItems.forall { item =>
-          expectedResult.getItems.contains(item)
-        } && expectedResult.getItems.size() == mainItems.size()
+        val diff = ObjectDifferBuilder
+          .buildDefault()
+          .compare(mainItems, expectedResult.getItems)
         assert(
-          itemsTest,
-          s"Scalac Main CLasses Items did not match! Expected: $expectedResult, got $mainItems"
+          !diff.hasChanges,
+          s"Scalac Main Classes Items did not match!\n${val visitor = new ToMapPrintingVisitor(mainItems, expectedResult.getItems)
+            diff.visit(visitor)
+            visitor.getMessagesAsString }"
         )
       })
   }
@@ -826,12 +830,23 @@ class TestClient(
       .toScala
       .map(result => result.getItems)
       .map(testItems => {
-        val itemsTest = testItems.forall { item =>
-          expectedResult.getItems.contains(item)
-        } && expectedResult.getItems.size() == testItems.size()
+        val diff = ObjectDifferBuilder
+          .startBuilding()
+          .identity()
+          .ofCollectionItems(NodePath.withRoot())
+          .via((working: Any, base: Any) => {
+            working
+              .asInstanceOf[ScalaTestClassesItem]
+              .getTarget == base.asInstanceOf[ScalaTestClassesItem].getTarget
+          })
+          .and()
+          .build()
+          .compare(testItems, expectedResult.getItems)
         assert(
-          itemsTest,
-          s"Scalac Test CLasses Items did not match! Expected: $expectedResult, got $testItems"
+          !diff.hasChanges,
+          s"Scalac Test Classes Items did not match!\n${val visitor = new ToMapPrintingVisitor(testItems, expectedResult.getItems)
+            diff.visit(visitor)
+            visitor.getMessagesAsString }"
         )
       })
   }

--- a/tests/src/test/scala/tests/MockClientSuite.scala
+++ b/tests/src/test/scala/tests/MockClientSuite.scala
@@ -122,10 +122,26 @@ class MockClientSuite extends AnyFunSuite {
   }
 
   test("Run  javacOptions") {
+    val classDirectory = "file:" + testDirectory.resolve("out").toString
     val javacOptionsItems = List(
-      new JavacOptionsItem(targetId1, Collections.emptyList(), List("guava").asJava, "out"),
-      new JavacOptionsItem(targetId2, Collections.emptyList(), List("guava").asJava, "out"),
-      new JavacOptionsItem(targetId3, Collections.emptyList(), List("guava").asJava, "out")
+      new JavacOptionsItem(
+        targetId1,
+        Collections.emptyList(),
+        List("guava.jar").asJava,
+        classDirectory
+      ),
+      new JavacOptionsItem(
+        targetId2,
+        Collections.emptyList(),
+        List("guava.jar").asJava,
+        classDirectory
+      ),
+      new JavacOptionsItem(
+        targetId3,
+        Collections.emptyList(),
+        List("guava.jar").asJava,
+        classDirectory
+      )
     ).asJava
 
     client.testJavacOptions(
@@ -135,24 +151,25 @@ class MockClientSuite extends AnyFunSuite {
   }
 
   test("Run  scalacOptions") {
+    val classDirectory = "file:" + testDirectory.resolve("out").toString
     val scalacOptionsItems = List(
       new ScalacOptionsItem(
         targetId1,
         Collections.emptyList(),
-        List("scala-library").asJava,
-        "out"
+        List("scala-library.jar").asJava,
+        classDirectory
       ),
       new ScalacOptionsItem(
         targetId2,
         Collections.emptyList(),
-        List("scala-library").asJava,
-        "out"
+        List("scala-library.jar").asJava,
+        classDirectory
       ),
       new ScalacOptionsItem(
         targetId3,
         Collections.emptyList(),
-        List("scala-library").asJava,
-        "out"
+        List("scala-library.jar").asJava,
+        classDirectory
       )
     ).asJava
 


### PR DESCRIPTION
In PR #325, I have missed the negation in some of the test cases. These test cases broke after my refactoring, but these two bugs canceled each other, so that the build was still passing.

This pull request fixes those tests and refactors the remaining helper methods in `TestClient` to make use of the java-object-diff library.