### PR TITLE
feat: add `code` field to `Diagnostic` and add `TextEdit`

### DIFF
--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Diagnostic.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Diagnostic.java
@@ -1,6 +1,9 @@
 package ch.epfl.scala.bsp4j;
 
 import java.util.List;
+
+import com.google.gson.annotations.JsonAdapter;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -21,6 +24,9 @@ public class Diagnostic {
   private String message;
   
   private List<DiagnosticRelatedInformation> relatedInformation;
+
+  @JsonAdapter(JsonElementTypeAdapter.Factory.class)
+  private Object data;
   
   public Diagnostic(@NonNull final Range range, @NonNull final String message) {
     this.range = range;
@@ -82,6 +88,14 @@ public class Diagnostic {
   public void setRelatedInformation(final List<DiagnosticRelatedInformation> relatedInformation) {
     this.relatedInformation = relatedInformation;
   }
+  @Pure
+  public Object getData() {
+    return this.data;
+  }
+
+  public void setData(final Object data) {
+    this.data = data;
+  }
   
   @Override
   @Pure
@@ -93,6 +107,7 @@ public class Diagnostic {
     b.add("source", this.source);
     b.add("message", this.message);
     b.add("relatedInformation", this.relatedInformation);
+    b.add("data", this.data);
     return b.toString();
   }
   
@@ -136,6 +151,11 @@ public class Diagnostic {
         return false;
     } else if (!this.relatedInformation.equals(other.relatedInformation))
       return false;
+    if (this.data == null) {
+      if (other.data != null)
+        return false;
+    } else if (!this.data.equals(other.data))
+      return false;
     return true;
   }
   
@@ -149,6 +169,7 @@ public class Diagnostic {
     result = prime * result + ((this.code== null) ? 0 : this.code.hashCode());
     result = prime * result + ((this.source== null) ? 0 : this.source.hashCode());
     result = prime * result + ((this.message== null) ? 0 : this.message.hashCode());
-    return prime * result + ((this.relatedInformation== null) ? 0 : this.relatedInformation.hashCode());
+    result = prime * result + ((this.relatedInformation== null) ? 0 : this.relatedInformation.hashCode());
+    return prime * result + ((this.data== null) ? 0 : this.data.hashCode());
   }
 }

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TextEdit.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TextEdit.java
@@ -1,0 +1,85 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+
+@SuppressWarnings("all")
+public class TextEdit {
+
+    @NonNull
+    private Range range;
+
+    @NonNull
+    private String newText;
+
+    public TextEdit() {
+    }
+
+    public TextEdit(@NonNull final Range range, @NonNull final String newText) {
+        this.range = Preconditions.<Range>checkNotNull(range, "range");
+        this.newText = Preconditions.<String>checkNotNull(newText, "newText");
+    }
+
+    @Pure
+    @NonNull
+    public Range getRange() {
+        return this.range;
+    }
+
+    public void setRange(@NonNull final Range range) {
+        this.range = Preconditions.checkNotNull(range, "range");
+    }
+
+    @Pure
+    @NonNull
+    public String getNewText() {
+        return this.newText;
+    }
+
+    public void setNewText(@NonNull final String newText) {
+        this.newText = Preconditions.checkNotNull(newText, "newText");
+    }
+
+    @Override
+    @Pure
+    public String toString() {
+        ToStringBuilder b = new ToStringBuilder(this);
+        b.add("range", this.range);
+        b.add("newText", this.newText);
+        return b.toString();
+    }
+
+    @Override
+    @Pure
+    public boolean equals(final Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TextEdit other = (TextEdit) obj;
+        if (this.range == null) {
+            if (other.range != null)
+                return false;
+        } else if (!this.range.equals(other.range))
+            return false;
+        if (this.newText == null) {
+            if (other.newText != null)
+                return false;
+        } else if (!this.newText.equals(other.newText))
+            return false;
+        return true;
+    }
+
+    @Override
+    @Pure
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((this.range== null) ? 0 : this.range.hashCode());
+        return prime * result + ((this.newText== null) ? 0 : this.newText.hashCode());
+    }
+}


### PR DESCRIPTION
This `textEdit` is specified at https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEdit
This `code` field in `Diagnostic` is specified at https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic
