### PR TITLE
feat(ci): detect if there were file changes in CI when running `xtend`

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [master]
 jobs:
-  generate-and-test:
+  check-generation:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -14,12 +14,41 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
           cache: 'sbt'
+
       - name: generate xtend
         run: sbt bsp4j/xtend
+
+      - name: Verify Changed files
+        uses: tj-actions/verify-changed-files@v13
+        id: verify-changed-files
+        with:
+          files: |
+             **/*.java
+
+      - name: Fail if we detect changed files
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        run: |
+          echo "Detected changed files: ${{ steps.verify-changed-files.outputs.changed_files }}"
+          echo "Make sure to run 'sbt bsp4j/extend' before pushing."
+          exit 1
+
+  test:
+    needs: check-generation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'sbt'
+
       - name: compile
         run: sbt +compile +package
+
       - name: test
         run: sbt +test
+
   docs:
     name: Generate docs site
     runs-on: ubuntu-latest
@@ -31,6 +60,7 @@ jobs:
           java-version: '11'
           cache: 'sbt'
       - run: sbt docs/docusaurusCreateSite
+
   format-check:
     name: Format Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
Alright you can see a working example of this in https://github.com/build-server-protocol/build-server-protocol/actions/runs/3875530094/jobs/6608192646. The idea here is that if you commit stuff without running `xtend` first you'll have changes in your Java files. When that happens, it will fail the build and we won't then test. This is meant to help avoid what happened in https://github.com/build-server-protocol/build-server-protocol/pull/414 where tests all pass and everything was green even though the new code wasn't generated.