### PR TITLE
fix: ensure deployment works

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -5,6 +5,7 @@ module.exports = {
   "baseUrl": "/",
   "organizationName": "build-server-protocol",
   "projectName": "build-server-protocol.github.io",
+  "deploymentBranch": "master",
   "favicon": "img/favicon.ico",
   "customFields": {
     "blogSidebarCount": "ALL",


### PR DESCRIPTION
From looking at the failure in
https://github.com/build-server-protocol/build-server-protocol/actions/runs/3885907773/jobs/6630372169
it looks like we need `deploymentBranch` set. This change just adds
that.
