### PR TITLE
chore: redirect from `/build-server-protocol/` to `/`

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -37,6 +37,12 @@ module.exports = {
       {
         "fromExtensions": [
           "html"
+        ],
+        "redirects": [
+          {
+            "from": "/build-server-protocol/",
+            "to": "/"
+          }
         ]
       }
     ]


### PR DESCRIPTION
Since we use pages a bit different here and aren't actually following
the default `https://<org>.github.io/<repo>`, this is a hacky little way
to ensure that if for whatever reason someone goes through the
environments way in the repo to navigate to the site instead of just
clicking our url they'll actually get redirected to the right place.
