### PR TITLE
feat: add buildTarget/format method and canFormat capability

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
@@ -58,6 +58,9 @@ public interface BuildServer {
     @JsonRequest("buildTarget/dependencyModules")
     CompletableFuture<DependencyModulesResult> buildTargetDependencyModules(DependencyModulesParams params);
 
+    @JsonRequest("buildTarget/format")
+    CompletableFuture<Object> buildTargetFormat(FormatParams params);
+
     default void onConnectWithClient(BuildClient server) {
 
     }

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -33,12 +33,14 @@ class BuildTargetCapabilities {
   @NonNull Boolean canTest
   @NonNull Boolean canRun
   @NonNull Boolean canDebug
+  @NonNull Boolean canFormat
 
   new () {
     this.canCompile = Boolean.FALSE
     this.canTest = Boolean.FALSE
     this.canRun = Boolean.FALSE
     this.canDebug = Boolean.FALSE
+    this.canFormat = Boolean.FALSE
   }
 
   new (@NonNull Boolean canCompile, @NonNull Boolean canTest, @NonNull Boolean canRun) {
@@ -46,13 +48,15 @@ class BuildTargetCapabilities {
     this.canTest = canTest
     this.canRun = canRun
     this.canDebug = Boolean.FALSE
+    this.canFormat = Boolean.FALSE
   }
 
-  new (@NonNull Boolean canCompile, @NonNull Boolean canTest, @NonNull Boolean canRun, @NonNull Boolean canDebug) {
+  new (@NonNull Boolean canCompile, @NonNull Boolean canTest, @NonNull Boolean canRun, @NonNull Boolean canDebug, @NonNull Boolean canFormat) {
     this.canCompile = canCompile
     this.canTest = canTest
     this.canRun = canRun
     this.canDebug = canDebug
+    this.canFormat = canFormat
   }
 }
 
@@ -138,11 +142,20 @@ class DebugProvider {
 }
 
 @JsonRpcData
+class FormatProvider {
+  @NonNull List<String> languageIds
+  new(@NonNull List<String> languageIds) {
+    this.languageIds = languageIds
+  }
+}
+
+@JsonRpcData
 class BuildServerCapabilities {
   CompileProvider compileProvider
   TestProvider testProvider
   RunProvider runProvider
   DebugProvider debugProvider
+  FormatProvider formatProvider
   Boolean inverseSourcesProvider
   Boolean dependencySourcesProvider
   Boolean dependencyModulesProvider
@@ -724,3 +737,23 @@ class DependencyModule {
     this.version = version
   }
 }
+
+@JsonRpcData
+class FormatItem {
+  @NonNull BuildTargetIdentifier target
+  List<String> uris
+
+  new(@NonNull BuildTargetIdentifier target, List<String> uris) {
+    this.target = target
+    this.uris = uris
+  }
+}
+
+@JsonRpcData
+class FormatParams {
+  @NonNull List<FormatItem> formatItems
+  new(@NonNull List<FormatItem> formatItems) {
+    this.formatItems = formatItems
+  }
+}
+

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildServerCapabilities.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildServerCapabilities.java
@@ -13,6 +13,8 @@ public class BuildServerCapabilities {
 
   private DebugProvider debugProvider;
 
+  private FormatProvider formatProvider;
+
   private Boolean inverseSourcesProvider;
 
   private Boolean dependencySourcesProvider;
@@ -65,6 +67,15 @@ public class BuildServerCapabilities {
 
   public void setDebugProvider(final DebugProvider debugProvider) {
     this.debugProvider = debugProvider;
+  }
+
+  @Pure
+  public FormatProvider getFormatProvider() {
+    return this.formatProvider;
+  }
+
+  public void setFormatProvider(final FormatProvider formatProvider) {
+    this.formatProvider = formatProvider;
   }
 
   @Pure
@@ -156,6 +167,7 @@ public class BuildServerCapabilities {
     b.add("testProvider", this.testProvider);
     b.add("runProvider", this.runProvider);
     b.add("debugProvider", this.debugProvider);
+    b.add("formatProvider", this.formatProvider);
     b.add("inverseSourcesProvider", this.inverseSourcesProvider);
     b.add("dependencySourcesProvider", this.dependencySourcesProvider);
     b.add("dependencyModulesProvider", this.dependencyModulesProvider);
@@ -197,6 +209,11 @@ public class BuildServerCapabilities {
       if (other.debugProvider != null)
         return false;
     } else if (!this.debugProvider.equals(other.debugProvider))
+      return false;
+    if (this.formatProvider == null) {
+      if (other.formatProvider != null)
+        return false;
+    } else if (!this.formatProvider.equals(other.formatProvider))
       return false;
     if (this.inverseSourcesProvider == null) {
       if (other.inverseSourcesProvider != null)
@@ -255,6 +272,7 @@ public class BuildServerCapabilities {
     result = prime * result + ((this.testProvider== null) ? 0 : this.testProvider.hashCode());
     result = prime * result + ((this.runProvider== null) ? 0 : this.runProvider.hashCode());
     result = prime * result + ((this.debugProvider== null) ? 0 : this.debugProvider.hashCode());
+    result = prime * result + ((this.formatProvider== null) ? 0 : this.formatProvider.hashCode());
     result = prime * result + ((this.inverseSourcesProvider== null) ? 0 : this.inverseSourcesProvider.hashCode());
     result = prime * result + ((this.dependencySourcesProvider== null) ? 0 : this.dependencySourcesProvider.hashCode());
     result = prime * result + ((this.dependencyModulesProvider== null) ? 0 : this.dependencyModulesProvider.hashCode());

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetCapabilities.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetCapabilities.java
@@ -19,11 +19,15 @@ public class BuildTargetCapabilities {
   @NonNull
   private Boolean canDebug;
 
+  @NonNull
+  private Boolean canFormat;
+
   public BuildTargetCapabilities() {
     this.canCompile = Boolean.FALSE;
     this.canTest = Boolean.FALSE;
     this.canRun = Boolean.FALSE;
     this.canDebug = Boolean.FALSE;
+    this.canFormat = Boolean.FALSE;
   }
 
   public BuildTargetCapabilities(@NonNull final Boolean canCompile, @NonNull final Boolean canTest, @NonNull final Boolean canRun) {
@@ -31,13 +35,15 @@ public class BuildTargetCapabilities {
     this.canTest = canTest;
     this.canRun = canRun;
     this.canDebug = Boolean.FALSE;
+    this.canFormat = Boolean.FALSE;
   }
 
-  public BuildTargetCapabilities(@NonNull final Boolean canCompile, @NonNull final Boolean canTest, @NonNull final Boolean canRun, @NonNull final Boolean canDebug) {
+  public BuildTargetCapabilities(@NonNull final Boolean canCompile, @NonNull final Boolean canTest, @NonNull final Boolean canRun, @NonNull final Boolean canDebug, @NonNull final Boolean canFormat) {
     this.canCompile = canCompile;
     this.canTest = canTest;
     this.canRun = canRun;
     this.canDebug = canDebug;
+    this.canFormat = canFormat;
   }
 
   @Pure
@@ -80,6 +86,16 @@ public class BuildTargetCapabilities {
     this.canDebug = Preconditions.checkNotNull(canDebug, "canDebug");
   }
 
+  @Pure
+  @NonNull
+  public Boolean getCanFormat() {
+    return this.canFormat;
+  }
+
+  public void setCanFormat(@NonNull final Boolean canFormat) {
+    this.canFormat = Preconditions.checkNotNull(canFormat, "canFormat");
+  }
+
   @Override
   @Pure
   public String toString() {
@@ -88,6 +104,7 @@ public class BuildTargetCapabilities {
     b.add("canTest", this.canTest);
     b.add("canRun", this.canRun);
     b.add("canDebug", this.canDebug);
+    b.add("canFormat", this.canFormat);
     return b.toString();
   }
 
@@ -121,6 +138,11 @@ public class BuildTargetCapabilities {
         return false;
     } else if (!this.canDebug.equals(other.canDebug))
       return false;
+    if (this.canFormat == null) {
+      if (other.canFormat != null)
+        return false;
+    } else if (!this.canFormat.equals(other.canFormat))
+      return false;
     return true;
   }
 
@@ -132,6 +154,7 @@ public class BuildTargetCapabilities {
     result = prime * result + ((this.canCompile== null) ? 0 : this.canCompile.hashCode());
     result = prime * result + ((this.canTest== null) ? 0 : this.canTest.hashCode());
     result = prime * result + ((this.canRun== null) ? 0 : this.canRun.hashCode());
-    return prime * result + ((this.canDebug== null) ? 0 : this.canDebug.hashCode());
+    result = prime * result + ((this.canDebug== null) ? 0 : this.canDebug.hashCode());
+    return prime * result + ((this.canFormat== null) ? 0 : this.canFormat.hashCode());
   }
 }

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/FormatItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/FormatItem.java
@@ -1,0 +1,80 @@
+package ch.epfl.scala.bsp4j;
+
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class FormatItem {
+  @NonNull
+  private BuildTargetIdentifier target;
+
+  private List<String> uris;
+
+  public FormatItem(@NonNull final BuildTargetIdentifier target, final List<String> uris) {
+    this.target = target;
+    this.uris = uris;
+  }
+
+  @Pure
+  @NonNull
+  public BuildTargetIdentifier getTarget() {
+    return this.target;
+  }
+
+  public void setTarget(@NonNull final BuildTargetIdentifier target) {
+    this.target = Preconditions.checkNotNull(target, "target");
+  }
+
+  @Pure
+  public List<String> getUris() {
+    return this.uris;
+  }
+
+  public void setUris(final List<String> uris) {
+    this.uris = uris;
+  }
+
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("target", this.target);
+    b.add("uris", this.uris);
+    return b.toString();
+  }
+
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    FormatItem other = (FormatItem) obj;
+    if (this.target == null) {
+      if (other.target != null)
+        return false;
+    } else if (!this.target.equals(other.target))
+      return false;
+    if (this.uris == null) {
+      if (other.uris != null)
+        return false;
+    } else if (!this.uris.equals(other.uris))
+      return false;
+    return true;
+  }
+
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.target== null) ? 0 : this.target.hashCode());
+    return prime * result + ((this.uris== null) ? 0 : this.uris.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/FormatParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/FormatParams.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class FormatParams {
+  @NonNull
+  private List<FormatItem> formatItems;
+
+  public FormatParams(@NonNull final List<FormatItem> formatItems) {
+    this.formatItems = formatItems;
+  }
+
+  @Pure
+  @NonNull
+  public List<FormatItem> getFormatItems() {
+    return this.formatItems;
+  }
+
+  public void setFormatItems(@NonNull final List<FormatItem> formatItems) {
+    this.formatItems = Preconditions.checkNotNull(formatItems, "formatItems");
+  }
+
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("formatItems", this.formatItems);
+    return b.toString();
+  }
+
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    FormatParams other = (FormatParams) obj;
+    if (this.formatItems == null) {
+      if (other.formatItems != null)
+        return false;
+    } else if (!this.formatItems.equals(other.formatItems))
+      return false;
+    return true;
+  }
+
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.formatItems== null) ? 0 : this.formatItems.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/FormatProvider.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/FormatProvider.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class FormatProvider {
+  @NonNull
+  private List<String> languageIds;
+
+  public FormatProvider(@NonNull final List<String> languageIds) {
+    this.languageIds = languageIds;
+  }
+
+  @Pure
+  @NonNull
+  public List<String> getLanguageIds() {
+    return this.languageIds;
+  }
+
+  public void setLanguageIds(@NonNull final List<String> languageIds) {
+    this.languageIds = Preconditions.checkNotNull(languageIds, "languageIds");
+  }
+
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("languageIds", this.languageIds);
+    return b.toString();
+  }
+
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    FormatProvider other = (FormatProvider) obj;
+    if (this.languageIds == null) {
+      if (other.languageIds != null)
+        return false;
+    } else if (!this.languageIds.equals(other.languageIds))
+      return false;
+    return true;
+  }
+
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.languageIds== null) ? 0 : this.languageIds.hashCode());
+  }
+}

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -57,7 +57,8 @@ final case class BuildTargetCapabilities(
     canCompile: Boolean,
     canTest: Boolean,
     canRun: Boolean,
-    canDebug: Boolean = false // backward compatible default
+    canDebug: Boolean = false, // backward compatible default
+    canFormat: Boolean = false // backward compatible default
 )
 
 object BuildTargetCapabilities {
@@ -208,11 +209,21 @@ object DebugProvider {
     JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
+final case class FormatProvider(
+    languageIds: List[String]
+)
+
+object FormatProvider {
+  implicit val codec: JsonValueCodec[FormatProvider] =
+    JsonCodecMaker.makeWithRequiredCollectionFields
+}
+
 final case class BuildServerCapabilities(
     compileProvider: Option[CompileProvider],
     testProvider: Option[TestProvider],
     runProvider: Option[RunProvider],
     debugProvider: Option[DebugProvider],
+    formatProvider: Option[FormatProvider],
     inverseSourcesProvider: Option[Boolean],
     dependencySourcesProvider: Option[Boolean],
     dependencyModulesProvider: Option[Boolean],
@@ -920,6 +931,20 @@ final case class CleanCacheResult(
 
 object CleanCacheResult {
   implicit val codec: JsonValueCodec[CleanCacheResult] =
+    JsonCodecMaker.makeWithRequiredCollectionFields
+}
+
+final case class FormatItem(
+    target: BuildTargetIdentifier,
+    uris: Option[List[Uri]]
+)
+
+final case class FormatParams(
+    formatItems: List[FormatItem]
+)
+
+object FormatParams {
+  implicit val codec: JsonValueCodec[FormatParams] =
     JsonCodecMaker.makeWithRequiredCollectionFields
 }
 

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
@@ -26,6 +26,7 @@ trait BuildTarget {
   object test extends Endpoint[TestParams, TestResult]("buildTarget/test")
   object run extends Endpoint[RunParams, RunResult]("buildTarget/run")
   object cleanCache extends Endpoint[CleanCacheParams, CleanCacheResult]("buildTarget/cleanCache")
+  object format extends Endpoint[FormatParams, Unit]("buildTarget/format")
 
   object didChange extends Endpoint[DidChangeBuildTarget, Unit]("buildTarget/didChange")
 

--- a/docs/bindings/java.md
+++ b/docs/bindings/java.md
@@ -171,6 +171,7 @@ class MyBuildServer extends BuildServer {
   def buildTargetRun(params: RunParams): CompletableFuture[RunResult] = ???
   def buildTargetSources(params: SourcesParams): CompletableFuture[SourcesResult] = ???
   def buildTargetTest(params: TestParams): CompletableFuture[TestResult] = ???
+  def buildTargetFormat(params: FormatParams): CompletableFuture[Object] = ???
   def debugSessionStart(params: DebugSessionParams): CompletableFuture[DebugSessionAddress] = ???
   def onBuildExit(): Unit = ???
   def onBuildInitialized(): Unit = ???

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -217,6 +217,8 @@ export interface BuildTargetCapabilities {
   canRun: Boolean;
   /** This target can be debugged by the BSP server. */
   canDebug: Boolean;
+  /** This target's sources can be formatted by the BSP server. */
+  canFormat: Boolean;
 }
 ```
 
@@ -377,6 +379,9 @@ export interface BuildServerCapabilities {
   /** The languages the server supports debugging via method debugSession/start */
   debugProvider?: DebugProvider;
 
+  /** The languages the server supports formatting via method buildTarget/format */
+  formatProvider?: FormatProvider;
+
   /** The server can provide a list of targets that contain a
    * single text document via the method buildTarget/inverseSources */
   inverseSourcesProvider?: Boolean;
@@ -427,6 +432,10 @@ export interface DebugProvider {
 }
 
 export interface TestProvider {
+  languageIds: String[];
+}
+
+export interface FormatProvider {
   languageIds: String[];
 }
 ```
@@ -1525,3 +1534,41 @@ export interface CleanCacheResult {
   cleaned: Boolean;
 }
 ```
+
+### Format Request
+
+The format request is sent from the client to the server to format sources
+of a given build target.
+
+- method: `buildTarget/format`
+- params: `FormatParams`
+
+To request formatting of sources in one or several build targets,
+a list of items that should be formatted needs to be passed.
+
+```ts
+export interface FormatParams {
+  /** Items that should be formatted. */
+  formatItems: FormatItem[];
+}
+```
+
+Each item is defined as follows:
+
+```ts
+export interface FormatItem {
+  target: BuildTargetIdentifier;
+  uris?: Uri[];
+}
+```
+
+Each item should have an identifier of its build target and an optional
+list of files that should be formatted. If the list is empty or `null`,
+then all sources inside the build target should be formatted.
+
+Response:
+
+- result: `null`
+- error: JSON-RPC code and message set in case an exception happens during the
+  request.
+

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jGenerators.scala
@@ -84,7 +84,8 @@ trait Bsp4jGenerators {
     canTest <- arbitrary[Boolean]
     canRun <- arbitrary[Boolean]
     canDebug <- arbitrary[Boolean]
-  } yield new BuildTargetCapabilities(canCompile, canTest, canRun, canDebug)
+    canFormat <- arbitrary[Boolean]
+  } yield new BuildTargetCapabilities(canCompile, canTest, canRun, canDebug, canFormat)
 
   lazy val genBuildTargetEvent: Gen[BuildTargetEvent] = for {
     target <- genBuildTargetIdentifier

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jShrinkers.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/gen/Bsp4jShrinkers.scala
@@ -87,7 +87,8 @@ trait Bsp4jShrinkers extends UtilShrinkers {
         canTest <- shrink(capabilities.getCanTest)
         canRun <- shrink(capabilities.getCanRun)
         canDebug <- shrink(capabilities.getCanDebug)
-      } yield new BuildTargetCapabilities(canCompile, canTest, canRun, canDebug)
+        canFormat <- shrink(capabilities.getCanFormat)
+      } yield new BuildTargetCapabilities(canCompile, canTest, canRun, canDebug, canFormat)
   }
 
   implicit def shrinkBuildTargetEvent: Shrink[BuildTargetEvent] = Shrink { event =>

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
@@ -48,6 +48,7 @@ class HappyMockServer(base: File) extends AbstractMockServer {
     c.setTestProvider(new TestProvider(supportedLanguages))
     c.setRunProvider(new RunProvider(supportedLanguages))
     c.setDebugProvider(new DebugProvider(supportedLanguages))
+    c.setFormatProvider(new FormatProvider(supportedLanguages))
     c.setInverseSourcesProvider(true)
     c.setDependencySourcesProvider(true)
     c.setResourcesProvider(true)
@@ -74,14 +75,14 @@ class HappyMockServer(base: File) extends AbstractMockServer {
     List(BuildTargetTag.LIBRARY).asJava,
     languageIds,
     List.empty.asJava,
-    new BuildTargetCapabilities(true, false, false, false)
+    new BuildTargetCapabilities(true, false, false, false, false)
   )
   val target2 = new BuildTarget(
     targetId2,
     List(BuildTargetTag.TEST).asJava,
     languageIds,
     List(targetId1).asJava,
-    new BuildTargetCapabilities(true, true, false, false)
+    new BuildTargetCapabilities(true, true, false, false, false)
   )
 
   val target3 = new BuildTarget(
@@ -89,7 +90,7 @@ class HappyMockServer(base: File) extends AbstractMockServer {
     List(BuildTargetTag.APPLICATION).asJava,
     languageIds,
     List(targetId1).asJava,
-    new BuildTargetCapabilities(true, false, true, false)
+    new BuildTargetCapabilities(true, false, true, false, false)
   )
 
   val target4 = new BuildTarget(
@@ -97,7 +98,7 @@ class HappyMockServer(base: File) extends AbstractMockServer {
     List(BuildTargetTag.APPLICATION).asJava,
     cppLanguageId,
     List.empty.asJava,
-    new BuildTargetCapabilities(true, false, true, false)
+    new BuildTargetCapabilities(true, false, true, false, false)
   )
 
   val target5 = new BuildTarget(
@@ -105,7 +106,7 @@ class HappyMockServer(base: File) extends AbstractMockServer {
     List(BuildTargetTag.APPLICATION).asJava,
     pythonLanguageId,
     List.empty.asJava,
-    new BuildTargetCapabilities(true, false, true, false)
+    new BuildTargetCapabilities(true, false, true, false, false)
   )
 
   val compileTargets: Map[BuildTargetIdentifier, BuildTarget] = ListMap(
@@ -564,6 +565,11 @@ class HappyMockServer(base: File) extends AbstractMockServer {
       val result = new CleanCacheResult("cleaned cache", true)
       Right(result)
     }
+
+  override def buildTargetFormat(
+      params: FormatParams
+  ): CompletableFuture[AnyRef] =
+    CompletableFuture.completedFuture(null)
 
   override def buildTargetDependencyModules(
       params: DependencyModulesParams

--- a/tests/src/test/scala/tests/MockClientSuite.scala
+++ b/tests/src/test/scala/tests/MockClientSuite.scala
@@ -44,7 +44,7 @@ class MockClientSuite extends AnyFunSuite {
     List(BuildTargetTag.LIBRARY).asJava,
     languageIds,
     Collections.emptyList(),
-    new BuildTargetCapabilities(true, false, false, false)
+    new BuildTargetCapabilities(true, false, false, false, false)
   )
 
   val target2 = new BuildTarget(
@@ -52,28 +52,28 @@ class MockClientSuite extends AnyFunSuite {
     List(BuildTargetTag.TEST).asJava,
     languageIds,
     List(targetId1).asJava,
-    new BuildTargetCapabilities(true, true, false, false)
+    new BuildTargetCapabilities(true, true, false, false, false)
   )
   val target3 = new BuildTarget(
     targetId3,
     List(BuildTargetTag.APPLICATION).asJava,
     languageIds,
     List(targetId1).asJava,
-    new BuildTargetCapabilities(true, false, true, false)
+    new BuildTargetCapabilities(true, false, true, false, false)
   )
   val target4 = new BuildTarget(
     targetId4,
     List(BuildTargetTag.APPLICATION).asJava,
     List("cpp").asJava,
     List.empty.asJava,
-    new BuildTargetCapabilities(true, false, true, false)
+    new BuildTargetCapabilities(true, false, true, false, false)
   )
   val target5 = new BuildTarget(
     targetId5,
     List(BuildTargetTag.APPLICATION).asJava,
     List("python").asJava,
     List.empty.asJava,
-    new BuildTargetCapabilities(true, false, true, false)
+    new BuildTargetCapabilities(true, false, true, false, false)
   )
 
   private val client = TestClient(

--- a/tests/src/test/scala/tests/SerializationSuite.scala
+++ b/tests/src/test/scala/tests/SerializationSuite.scala
@@ -105,7 +105,7 @@ class SerializationSuite extends AnyFunSuite {
     assert(bsp4sValueDecoded == bsp4sValue)
   }
 
-  test("BuildTargetCapabilities - backward compatible canDebug") {
+  test("BuildTargetCapabilities - backward compatibility") {
     val legacyJson =
       """
         |{
@@ -121,9 +121,11 @@ class SerializationSuite extends AnyFunSuite {
     assert(bsp4jValue.getCanTest == bsp4sValue.canTest)
     assert(bsp4jValue.getCanRun == bsp4sValue.canRun)
     assert(bsp4jValue.getCanDebug == bsp4sValue.canDebug)
+    assert(bsp4jValue.getCanFormat == bsp4sValue.canFormat)
 
     assert(bsp4jValue.getCanDebug == false)
     assert(bsp4sValue.canDebug == false)
+    assert(bsp4sValue.canFormat == false)
   }
 
   test("ScalaTestClassesItem - backward compatible framework") {


### PR DESCRIPTION
Following the discussion here https://github.com/scalameta/metals-feature-requests/issues/334 this PR extends BSP to support formatting of source files.

I am not sure whether I have correctly approached unit testing in the project. Please pay attention to it because mostly, I have done tests by "mocking" the similar `builtTarget/cleanCache` request by copy-pasting its test code and changing the method. Also, please let me know if I should fix comments by adding additional commits or if it is allowed to force-push.

Motivation

- Some build servers that implement BSP can be aware of source code formatting but there is no way to trigger formatting in abstract way in build-tool-transparent way. Example: `scala-cli` is universal tool for running/compiling/testing (and formatting as well) Scala code. It also implements BSP. `scala-cli` does not require to have `.scalafmt.conf` file to format code because it has built-in default configuration. It is possible to format source files with `scala-cli` by running `scala-cli fmt` but it should be done via CLI interface from the shell. If one works with Scala code using `scala-cli` as BSP server and tries to trigger "code formatting" from LSP client/IDE it will require some additional movements - for example, if using Metals it's necessary to create `.scalafmt.conf` file to use formatting capability of Metals (because Metals does not know that `scala-cli` knows how to do code format and that it does not require `.scalafmt.conf`). We also can imagine the case where `scala-cli` or similar tool even do not use `scalafmt` under the hood - for example, IntelliJ has built-in code formatter that is not `scalafmt`.
- Build server can manage source files written in different languages. Example: `sbt` can build projects based on both Scala and Java sources. If you work with Scala as a primary language in the project the only way to ensure that Java sources are formatted properly is to use separate tool or have IDE with Java support (IntelliJ) or install Java LSP client for Java if you use VSCode/Nvim/etc. Since `sbt` is already aware of Java sources in the project it seems to be a nice fit for it to implement Java source formatting capability - not in the `sbt` itself but for example using `sbt` plugin. Another example is `ScalaPB`. If you use it in `sbt` it comes in form of plugin that runs Protobuf compiler for Scala from `.proto` sources in your project. `ScalaPB` sbt plugin also seems a very good place to implement `.proto` formatting while currently it is possible only using external tools or IDE/LSP client.