### PR TITLE
fix(docs): update instructions on editing a page

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -7,7 +7,7 @@ sidebar_label: Specification
 This document is the specification of the Build Server Protocol (BSP).
 
 Edits to this specification can be made via a pull request against this markdown
-document, see "edit" button at the top of this page on the website.
+document, see "edit" button at the bottom of this page on the website.
 
 ## Motivation
 


### PR DESCRIPTION
Edit button is now on the bottom.