### PR TITLE
docs: align BSP diagnostics clearing with LSP behavior

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -612,6 +612,9 @@ using the appropriate value in the `reset` field. Clients generate new
 diagnostics by calling any BSP endpoint that triggers a `buildTarget/compile`,
 such as `buildTarget/compile`, `buildTarget/test` and `buildTarget/run`.
 
+If the computed set of diagnostic is empty, the server must push an empty array
+with `reset` set to true, in order to clear previous diagnostics.
+
 The optional `originId` field in the definition of `PublishDiagnosticsParams`
 can be used by clients to know which request originated the notification. This
 field will be defined if the client defined it in the original request that


### PR DESCRIPTION
Update the BSP specification to clarify that servers should send `build/publishDiagnostics` with an empty diagnostics array to clear former diagnostics.
This change addresses the inconsistencies among various BSP servers and aligns the behavior with the Language Server Protoco, providing a more consistent experience for clients such as `scalameta/metals`.

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics

close https://github.com/build-server-protocol/build-server-protocol/issues/481