### PR TITLE
Make the list of targets in WorkspaceBuildTargetsResult required

### DIFF
--- a/codegen/src/test/scala/DocsApprovalTest.docsAreApproved.approved.txt
+++ b/codegen/src/test/scala/DocsApprovalTest.docsAreApproved.approved.txt
@@ -496,7 +496,7 @@ for the list of all available build targets in the workspace.
 export interface WorkspaceBuildTargetsResult {
   /** The build targets in this workspace that
    * contain sources with the given language ids. */
-  targets?: BuildTarget[];
+  targets: BuildTarget[];
 }
 ```
 

--- a/spec/src/main/resources/META-INF/smithy/bsp/bsp.smithy
+++ b/spec/src/main/resources/META-INF/smithy/bsp/bsp.smithy
@@ -820,7 +820,7 @@ list DiagnosticRelatedInformationList {
 structure WorkspaceBuildTargetsResult {
     /// The build targets in this workspace that
     /// contain sources with the given language ids.
-    // TODO: should be @required
+    @required
     targets: BuildTargets
 }
 


### PR DESCRIPTION
Technically that's not a breaking change because
1. It never made sense *not* to return the list of targets
2. Support libraries treated this field as required anyway