### PR TITLE
Less dependency bump PRs.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,18 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*" # All updates are grouped in 1 PR
 
   - package-ecosystem: "npm"
     directory: "/website"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    # Create a group of dependencies to be updated together in one pull request
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*" # All updates are grouped in 1 PR

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -25,7 +25,43 @@
 # Default: @asap
 #
 #pullRequests.frequency = "0 0 ? * 3" # every thursday on midnight
-pullRequests.frequency = "7 days"
+pullRequests.frequency = "0 0 0 1 * *" # At 12:00 AM, on day 1 of the month - to match dependabot `monthly` schedule
+
+# pullRequests.grouping allows you to specify how Scala Steward should group
+# your updates in order to reduce the number of pull-requests.
+#
+# Updates will be placed in the first group with which they match, starting
+# from the first in the array. Those that do not match any group will follow
+# the default procedure (one PR per update).
+#
+# Each element in the array will have the following schema:
+#
+#   - name (mandatory): the name of the group, will be used for things like naming the branch
+#   - title (optional): if provided it will be used as the title for the PR
+#   - filter (mandatory): a non-empty list containing the filters to use to know
+#                         if an update falls into this group.
+#
+# `filter` properties would have this format:
+#
+#    {
+#       version = "major" | "minor" | "patch" | "pre-release" | "build-metadata",
+#       group = "{group}",
+#       artifact = "{artifact}"
+#    }
+#
+# For more information on the values for the `version` filter visit https://semver.org/
+#
+# Every field in a `filter` is optional but at least one must be provided.
+#
+# For grouping every update together a filter like {group = "*"} can be # provided.
+#
+# To create a new PR for each unique combination of artifact-versions, include ${hash} in the name.
+#
+# Default: []
+pullRequests.grouping = [
+  { name = "major", "title" = "Major updates", "filter" = [ {"version" = "major"}] },
+  { name = "all", "title" = "Dependency updates", "filter" = [{"group" = "*"}] }
+]
 
 # Only these dependencies which match the given patterns are updated.
 #


### PR DESCRIPTION
Configure scala-steward and dependabot to do grouped dependency bump PRs on the first of each month. Generally this should be an appropriate interval as most updates are not time-critical. This change should decrease amount of notifications for maintainers somewhat.