### PR TITLE
Split TaskData into TaskStartData, TaskProgressData and TaskFinishData

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/TaskFinishDataKind.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/TaskFinishDataKind.java
@@ -1,0 +1,7 @@
+package ch.epfl.scala.bsp4j;
+
+public class TaskFinishDataKind {
+    public static final String COMPILE_REPORT = "compile-report";
+    public static final String TEST_FINISH = "test-finish";
+    public static final String TEST_REPORT = "test-report";
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/TaskProgressDataKind.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/TaskProgressDataKind.java
@@ -1,0 +1,4 @@
+package ch.epfl.scala.bsp4j;
+
+public class TaskProgressDataKind {
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/TaskStartDataKind.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/TaskStartDataKind.java
@@ -1,0 +1,7 @@
+package ch.epfl.scala.bsp4j;
+
+public class TaskStartDataKind {
+    public static final String COMPILE_TASK = "compile-task";
+    public static final String TEST_START = "test-start";
+    public static final String TEST_TASK = "test-task";
+}

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -1165,13 +1165,10 @@ object StatusCode {
     }
   }
 }
-object TaskDataKind {
+object TaskFinishDataKind {
   val CompileReport = "compile-report"
-  val CompileTask = "compile-task"
   val TestFinish = "test-finish"
   val TestReport = "test-report"
-  val TestStart = "test-start"
-  val TestTask = "test-task"
 }
 
 final case class TaskFinishParams(
@@ -1197,6 +1194,8 @@ object TaskId {
   implicit val codec: JsonValueCodec[TaskId] = JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
+object TaskProgressDataKind {}
+
 final case class TaskProgressParams(
     taskId: TaskId,
     eventTime: Option[Long],
@@ -1211,6 +1210,12 @@ final case class TaskProgressParams(
 object TaskProgressParams {
   implicit val codec: JsonValueCodec[TaskProgressParams] =
     JsonCodecMaker.makeWithRequiredCollectionFields
+}
+
+object TaskStartDataKind {
+  val CompileTask = "compile-task"
+  val TestStart = "test-start"
+  val TestTask = "test-task"
 }
 
 final case class TaskStartParams(

--- a/codegen/src/test/resources/DocsApprovalTest.bsp.approved.txt
+++ b/codegen/src/test/resources/DocsApprovalTest.bsp.approved.txt
@@ -1578,17 +1578,17 @@ export interface TaskStartParams {
   message?: string;
 
   /** Kind of data to expect in the `data` field. If this field is not set, the kind of data is not specified. */
-  dataKind?: TaskDataKind;
+  dataKind?: TaskStartDataKind;
 
   /** Optional metadata about the task.
    * Objects for specific tasks like compile, test, etc are specified in the protocol. */
-  data?: TaskData;
+  data?: TaskStartData;
 }
 ```
 
-#### TaskDataKind
+#### TaskStartDataKind
 
-Task progress notifications may contain an arbitrary interface in their `data`
+Task start notifications may contain an arbitrary interface in their `data`
 field. The kind of interface that is contained in a notification must be
 specified in the `dataKind` field.
 
@@ -1596,20 +1596,11 @@ There are predefined kinds of objects for compile and test tasks, as described
 in [[bsp#BuildTargetCompile]] and [[bsp#BuildTargetTest]]
 
 ```ts
-export type TaskDataKind = string;
+export type TaskStartDataKind = string;
 
-export namespace TaskDataKind {
-  /** `data` field must contain a CompileReport object. */
-  export const CompileReport = "compile-report";
-
+export namespace TaskStartDataKind {
   /** `data` field must contain a CompileTask object. */
   export const CompileTask = "compile-task";
-
-  /** `data` field must contain a TestFinish object. */
-  export const TestFinish = "test-finish";
-
-  /** `data` field must contain a TestReport object. */
-  export const TestReport = "test-report";
 
   /** `data` field must contain a TestStart object. */
   export const TestStart = "test-start";
@@ -1619,9 +1610,9 @@ export namespace TaskDataKind {
 }
 ```
 
-#### TaskData
+#### TaskStartData
 
-Task progress notifications may contain an arbitrary interface in their `data`
+Task start notifications may contain an arbitrary interface in their `data`
 field. The kind of interface that is contained in a notification must be
 specified in the `dataKind` field.
 
@@ -1629,7 +1620,180 @@ There are predefined kinds of objects for compile and test tasks, as described
 in [[bsp#BuildTargetCompile]] and [[bsp#BuildTargetTest]]
 
 ```ts
-export type TaskData = any;
+export type TaskStartData = any;
+```
+
+#### CompileTask
+
+The beginning of a compilation unit may be signalled to the client with a
+`build/taskStart` notification. When the compilation unit is a build target, the
+notification's `dataKind` field must be "compile-task" and the `data` field must
+include a `CompileTask` object:
+
+```ts
+export interface CompileTask {
+  target: BuildTargetIdentifier;
+}
+```
+
+#### TestStart
+
+
+```ts
+export interface TestStart {
+  /** Name or description of the test. */
+  displayName: string;
+
+  /** Source location of the test, as LSP location. */
+  location?: Location;
+}
+```
+
+#### TestTask
+
+The beginning of a testing unit may be signalled to the client with a
+`build/taskStart` notification. When the testing unit is a build target, the
+notification's `dataKind` field must be `test-task` and the `data` field must
+include a `TestTask` object.
+
+```ts
+export interface TestTask {
+  target: BuildTargetIdentifier;
+}
+```
+
+### OnBuildTaskProgress: notification
+
+After a `taskStart` and before `taskFinish` for a `taskId`, the server may send
+any number of progress notifications.
+
+- method: `build/taskProgress`
+- params: `TaskProgressParams`
+
+#### TaskProgressParams
+
+
+```ts
+export interface TaskProgressParams {
+  /** Unique id of the task with optional reference to parent task id */
+  taskId: TaskId;
+
+  /** Timestamp of when the event started in milliseconds since Epoch. */
+  eventTime?: Long;
+
+  /** Message describing the task. */
+  message?: string;
+
+  /** If known, total amount of work units in this task. */
+  total?: Long;
+
+  /** If known, completed amount of work units in this task. */
+  progress?: Long;
+
+  /** Name of a work unit. For example, "files" or "tests". May be empty. */
+  unit?: string;
+
+  /** Kind of data to expect in the `data` field. If this field is not set, the kind of data is not specified. */
+  dataKind?: TaskProgressDataKind;
+
+  /** Optional metadata about the task.
+   * Objects for specific tasks like compile, test, etc are specified in the protocol. */
+  data?: TaskProgressData;
+}
+```
+
+#### TaskProgressDataKind
+
+Task progress notifications may contain an arbitrary interface in their `data`
+field. The kind of interface that is contained in a notification must be
+specified in the `dataKind` field.
+
+```ts
+export type TaskProgressDataKind = string;
+
+export namespace TaskProgressDataKind {
+}
+```
+
+#### TaskProgressData
+
+Task progress notifications may contain an arbitrary interface in their `data`
+field. The kind of interface that is contained in a notification must be
+specified in the `dataKind` field.
+
+```ts
+export type TaskProgressData = any;
+```
+
+### OnBuildTaskFinish: notification
+
+A `build/taskFinish` notification must always be sent after a `build/taskStart`
+with the same `taskId` was sent.
+
+- method: `build/taskFinish`
+- params: `TaskFinishParams`
+
+#### TaskFinishParams
+
+
+```ts
+export interface TaskFinishParams {
+  /** Unique id of the task with optional reference to parent task id */
+  taskId: TaskId;
+
+  /** Timestamp of when the event started in milliseconds since Epoch. */
+  eventTime?: Long;
+
+  /** Message describing the task. */
+  message?: string;
+
+  /** Task completion status. */
+  status: StatusCode;
+
+  /** Kind of data to expect in the `data` field. If this field is not set, the kind of data is not specified. */
+  dataKind?: TaskFinishDataKind;
+
+  /** Optional metadata about the task.
+   * Objects for specific tasks like compile, test, etc are specified in the protocol. */
+  data?: TaskFinishData;
+}
+```
+
+#### TaskFinishDataKind
+
+Task finish notifications may contain an arbitrary interface in their `data`
+field. The kind of interface that is contained in a notification must be
+specified in the `dataKind` field.
+
+There are predefined kinds of objects for compile and test tasks, as described
+in [[bsp#BuildTargetCompile]] and [[bsp#BuildTargetTest]]
+
+```ts
+export type TaskFinishDataKind = string;
+
+export namespace TaskFinishDataKind {
+  /** `data` field must contain a CompileReport object. */
+  export const CompileReport = "compile-report";
+
+  /** `data` field must contain a TestFinish object. */
+  export const TestFinish = "test-finish";
+
+  /** `data` field must contain a TestReport object. */
+  export const TestReport = "test-report";
+}
+```
+
+#### TaskFinishData
+
+Task finish notifications may contain an arbitrary interface in their `data`
+field. The kind of interface that is contained in a notification must be
+specified in the `dataKind` field.
+
+There are predefined kinds of objects for compile and test tasks, as described
+in [[bsp#BuildTargetCompile]] and [[bsp#BuildTargetTest]]
+
+```ts
+export type TaskFinishData = any;
 ```
 
 #### CompileReport
@@ -1658,19 +1822,6 @@ export interface CompileReport {
 
   /** The compilation was a noOp compilation. */
   noOp?: boolean;
-}
-```
-
-#### CompileTask
-
-The beginning of a compilation unit may be signalled to the client with a
-`build/taskStart` notification. When the compilation unit is a build target, the
-notification's `dataKind` field must be "compile-task" and the `data` field must
-include a `CompileTask` object:
-
-```ts
-export interface CompileTask {
-  target: BuildTargetIdentifier;
 }
 ```
 

--- a/codegen/src/test/resources/DocsApprovalTest.bsp.approved.txt
+++ b/codegen/src/test/resources/DocsApprovalTest.bsp.approved.txt
@@ -1920,134 +1920,36 @@ export interface TestReport {
 }
 ```
 
-#### TestStart
-
-
-```ts
-export interface TestStart {
-  /** Name or description of the test. */
-  displayName: string;
-
-  /** Source location of the test, as LSP location. */
-  location?: Location;
-}
-```
-
-#### TestTask
-
-The beginning of a testing unit may be signalled to the client with a
-`build/taskStart` notification. When the testing unit is a build target, the
-notification's `dataKind` field must be `test-task` and the `data` field must
-include a `TestTask` object.
-
-```ts
-export interface TestTask {
-  target: BuildTargetIdentifier;
-}
-```
-
-### OnBuildTaskProgress: notification
-
-After a `taskStart` and before `taskFinish` for a `taskId`, the server may send
-any number of progress notifications.
-
-- method: `build/taskProgress`
-- params: `TaskProgressParams`
-
-#### TaskProgressParams
-
-
-```ts
-export interface TaskProgressParams {
-  /** Unique id of the task with optional reference to parent task id */
-  taskId: TaskId;
-
-  /** Timestamp of when the event started in milliseconds since Epoch. */
-  eventTime?: Long;
-
-  /** Message describing the task. */
-  message?: string;
-
-  /** If known, total amount of work units in this task. */
-  total?: Long;
-
-  /** If known, completed amount of work units in this task. */
-  progress?: Long;
-
-  /** Name of a work unit. For example, "files" or "tests". May be empty. */
-  unit?: string;
-
-  /** Kind of data to expect in the `data` field. If this field is not set, the kind of data is not specified. */
-  dataKind?: TaskDataKind;
-
-  /** Optional metadata about the task.
-   * Objects for specific tasks like compile, test, etc are specified in the protocol. */
-  data?: TaskData;
-}
-```
-
-### OnBuildTaskFinish: notification
-
-A `build/taskFinish` notification must always be sent after a `build/taskStart`
-with the same `taskId` was sent.
-
-- method: `build/taskFinish`
-- params: `TaskFinishParams`
-
-#### TaskFinishParams
-
-
-```ts
-export interface TaskFinishParams {
-  /** Unique id of the task with optional reference to parent task id */
-  taskId: TaskId;
-
-  /** Timestamp of when the event started in milliseconds since Epoch. */
-  eventTime?: Long;
-
-  /** Message describing the task. */
-  message?: string;
-
-  /** Task completion status. */
-  status: StatusCode;
-
-  /** Kind of data to expect in the `data` field. If this field is not set, the kind of data is not specified. */
-  dataKind?: TaskDataKind;
-
-  /** Optional metadata about the task.
-   * Objects for specific tasks like compile, test, etc are specified in the protocol. */
-  data?: TaskData;
-}
-```
-
-## TaskData kinds
+## TaskFinishData kinds
 
 ### CompileReport
 This structure is embedded in
-the `data?: TaskData` field, when
+the `data?: TaskFinishData` field, when
 the `dataKind` field contains `"compile-report"`.
-
-### CompileTask
-This structure is embedded in
-the `data?: TaskData` field, when
-the `dataKind` field contains `"compile-task"`.
 
 ### TestFinish
 This structure is embedded in
-the `data?: TaskData` field, when
+the `data?: TaskFinishData` field, when
 the `dataKind` field contains `"test-finish"`.
 
 ### TestReport
 This structure is embedded in
-the `data?: TaskData` field, when
+the `data?: TaskFinishData` field, when
 the `dataKind` field contains `"test-report"`.
+
+## TaskStartData kinds
+
+### CompileTask
+This structure is embedded in
+the `data?: TaskStartData` field, when
+the `dataKind` field contains `"compile-task"`.
 
 ### TestStart
 This structure is embedded in
-the `data?: TaskData` field, when
+the `data?: TaskStartData` field, when
 the `dataKind` field contains `"test-start"`.
 
 ### TestTask
 This structure is embedded in
-the `data?: TaskData` field, when
+the `data?: TaskStartData` field, when
 the `dataKind` field contains `"test-task"`.

--- a/spec/src/main/resources/META-INF/smithy/bsp/bsp.smithy
+++ b/spec/src/main/resources/META-INF/smithy/bsp/bsp.smithy
@@ -1053,14 +1053,29 @@ intEnum OutputPathItemKind {
 }
 
 
-/// Task progress notifications may contain an arbitrary interface in their `data`
+/// Task start notifications may contain an arbitrary interface in their `data`
 /// field. The kind of interface that is contained in a notification must be
 /// specified in the `dataKind` field.
 ///
 /// There are predefined kinds of objects for compile and test tasks, as described
 /// in [[bsp#BuildTargetCompile]] and [[bsp#BuildTargetTest]]
 @data
-document TaskData
+document TaskStartData
+
+/// Task progress notifications may contain an arbitrary interface in their `data`
+/// field. The kind of interface that is contained in a notification must be
+/// specified in the `dataKind` field.
+@data
+document TaskProgressData
+
+/// Task finish notifications may contain an arbitrary interface in their `data`
+/// field. The kind of interface that is contained in a notification must be
+/// specified in the `dataKind` field.
+///
+/// There are predefined kinds of objects for compile and test tasks, as described
+/// in [[bsp#BuildTargetCompile]] and [[bsp#BuildTargetTest]]
+@data
+document TaskFinishData
 
 structure TaskStartParams {
     /// Unique id of the task with optional reference to parent task id
@@ -1075,7 +1090,7 @@ structure TaskStartParams {
 
     /// Optional metadata about the task.
     /// Objects for specific tasks like compile, test, etc are specified in the protocol.
-    data: TaskData
+    data: TaskStartData
 }
 
 structure TaskProgressParams {
@@ -1100,7 +1115,7 @@ structure TaskProgressParams {
 
     /// Optional metadata about the task.
     /// Objects for specific tasks like compile, test, etc are specified in the protocol.
-    data: TaskData
+    data: TaskProgressData
 }
 
 structure TaskFinishParams {
@@ -1120,7 +1135,7 @@ structure TaskFinishParams {
 
     /// Optional metadata about the task.
     /// Objects for specific tasks like compile, test, etc are specified in the protocol.
-    data: TaskData
+    data: TaskFinishData
 }
 
 
@@ -1162,7 +1177,7 @@ structure CompileResult {
 /// `build/taskStart` notification. When the compilation unit is a build target, the
 /// notification's `dataKind` field must be "compile-task" and the `data` field must
 /// include a `CompileTask` object:
-@dataKind(kind: "compile-task", extends: [TaskData])
+@dataKind(kind: "compile-task", extends: [TaskStartData])
 structure CompileTask {
     @required
     target: BuildTargetIdentifier
@@ -1173,7 +1188,7 @@ structure CompileTask {
 /// `build/taskFinish` notification. When the compilation unit is a build target,
 /// the notification's `dataKind` field must be `compile-report` and the `data`
 /// field must include a `CompileReport` object:
-@dataKind(kind: "compile-report", extends: [TaskData])
+@dataKind(kind: "compile-report", extends: [TaskFinishData])
 structure CompileReport {
     /// The build target that was compiled.
     @required
@@ -1238,13 +1253,13 @@ structure TestResult {
 /// `build/taskStart` notification. When the testing unit is a build target, the
 /// notification's `dataKind` field must be `test-task` and the `data` field must
 /// include a `TestTask` object.
-@dataKind(kind: "test-task", extends: [TaskData])
+@dataKind(kind: "test-task", extends: [TaskStartData])
 structure TestTask {
     @required
     target: BuildTargetIdentifier
 }
 
-@dataKind(kind: "test-report", extends: [TaskData])
+@dataKind(kind: "test-report", extends: [TaskFinishData])
 structure TestReport {
     originId: Identifier
     /// The build target that was compiled.
@@ -1275,7 +1290,7 @@ structure TestReport {
     time: Long
 }
 
-@dataKind(kind: "test-start", extends: [TaskData])
+@dataKind(kind: "test-start", extends: [TaskStartData])
 structure TestStart {
     /// Name or description of the test.
     @required
@@ -1288,7 +1303,7 @@ structure TestStart {
 @data
 document TestFinishData
 
-@dataKind(kind: "test-finish", extends: [TaskData])
+@dataKind(kind: "test-finish", extends: [TaskFinishData])
 structure TestFinish {
     /// Name or description of the test.
     @required

--- a/tests/src/test/scala/tests/SerializationSuite.scala
+++ b/tests/src/test/scala/tests/SerializationSuite.scala
@@ -28,7 +28,7 @@ class SerializationSuite extends AnyFunSuite {
       Some(12345),
       Some("message"),
       bsp4s.StatusCode.Ok,
-      Some(bsp4s.TaskDataKind.CompileReport),
+      Some(bsp4s.TaskFinishDataKind.CompileReport),
       Option(RawJson(writeToArray(report)))
     )
 


### PR DESCRIPTION
It makes more sense to keep these kinds separate