### PR TITLE
Restore the scala-attach-remote data kind

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/DebugSessionParamsDataKind.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/DebugSessionParamsDataKind.java
@@ -1,6 +1,7 @@
 package ch.epfl.scala.bsp4j;
 
 public class DebugSessionParamsDataKind {
+    public static final String SCALA_ATTACH_REMOTE = "scala-attach-remote";
     public static final String SCALA_MAIN_CLASS = "scala-main-class";
     public static final String SCALA_TEST_SUITES = "scala-test-suites";
     public static final String SCALA_TEST_SUITES_SELECTION = "scala-test-suites-selection";

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/ScalaAttachRemote.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/ScalaAttachRemote.java
@@ -1,0 +1,35 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ScalaAttachRemote {
+  public ScalaAttachRemote() {
+  }
+
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    return b.toString();
+  }
+
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    return true;
+  }
+
+  @Override
+  @Pure
+  public int hashCode() {
+    return 1;
+  }
+}

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -318,6 +318,7 @@ object DebugSessionParams {
 }
 
 object DebugSessionParamsDataKind {
+  val ScalaAttachRemote = "scala-attach-remote"
   val ScalaMainClass = "scala-main-class"
   val ScalaTestSuites = "scala-test-suites"
   val ScalaTestSuitesSelection = "scala-test-suites-selection"
@@ -882,6 +883,14 @@ final case class ScalaAction(
 
 object ScalaAction {
   implicit val codec: JsonValueCodec[ScalaAction] = JsonCodecMaker.makeWithRequiredCollectionFields
+}
+
+final case class ScalaAttachRemote(
+)
+
+object ScalaAttachRemote {
+  implicit val codec: JsonValueCodec[ScalaAttachRemote] =
+    JsonCodecMaker.makeWithRequiredCollectionFields
 }
 
 final case class ScalaBuildTarget(

--- a/codegen/src/test/resources/DocsApprovalTest.bsp.approved.txt
+++ b/codegen/src/test/resources/DocsApprovalTest.bsp.approved.txt
@@ -1140,6 +1140,9 @@ export interface DebugSessionParams {
 export type DebugSessionParamsDataKind = string;
 
 export namespace DebugSessionParamsDataKind {
+  /** `data` field must contain a ScalaAttachRemote object. */
+  export const ScalaAttachRemote = "scala-attach-remote";
+
   /** `data` field must contain a ScalaMainClass object. */
   export const ScalaMainClass = "scala-main-class";
 

--- a/codegen/src/test/resources/DocsApprovalTest.bsp.scala.approved.txt
+++ b/codegen/src/test/resources/DocsApprovalTest.bsp.scala.approved.txt
@@ -215,7 +215,7 @@ the `dataKind` field contains `"scala-attach-remote"`.
 
 #### ScalaAttachRemote
 
-TODO
+The debug session will connect to a running process. The DAP client will send the port of the running process later.
 
 ```ts
 export interface ScalaAttachRemote {

--- a/codegen/src/test/resources/DocsApprovalTest.bsp.scala.approved.txt
+++ b/codegen/src/test/resources/DocsApprovalTest.bsp.scala.approved.txt
@@ -208,6 +208,20 @@ the `dataKind` field contains `"scala-main-class"`.
 
 ## DebugSessionParamsData kinds
 
+### ScalaAttachRemote
+This structure is embedded in
+the `data?: DebugSessionParamsData` field, when
+the `dataKind` field contains `"scala-attach-remote"`.
+
+#### ScalaAttachRemote
+
+TODO
+
+```ts
+export interface ScalaAttachRemote {
+}
+```
+
 ### ScalaMainClass
 This structure is embedded in
 the `data?: DebugSessionParamsData` field, when

--- a/spec/src/main/resources/META-INF/smithy/bsp/extensions/scala.smithy
+++ b/spec/src/main/resources/META-INF/smithy/bsp/extensions/scala.smithy
@@ -258,7 +258,7 @@ list ScalaTestSuiteClasses {
     member: String
 }
 
-/// TODO
+/// The debug session will connect to a running process. The DAP client will send the port of the running process later.
 @dataKind(kind: "scala-attach-remote", extends: [DebugSessionParamsData])
 structure ScalaAttachRemote {
 }

--- a/spec/src/main/resources/META-INF/smithy/bsp/extensions/scala.smithy
+++ b/spec/src/main/resources/META-INF/smithy/bsp/extensions/scala.smithy
@@ -258,6 +258,11 @@ list ScalaTestSuiteClasses {
     member: String
 }
 
+/// TODO
+@dataKind(kind: "scala-attach-remote", extends: [DebugSessionParamsData])
+structure ScalaAttachRemote {
+}
+
 @dataKind(kind: "scala-test-suites-selection", extends: [DebugSessionParamsData])
 structure ScalaTestSuites {
     /// The fully qualified names of the test classes in this target and the tests in this test classes


### PR DESCRIPTION
@ckipp01 @adpi2 could you please provide the description of this data kind? In the old doc [it wasn't very well documented](https://github.com/build-server-protocol/build-server-protocol/blob/v2.1.0-M4/docs/extensions/scala.md#scala-specific-data-kinds-for-debugging)
![image](https://github.com/build-server-protocol/build-server-protocol/assets/1674445/14c881df-9898-45a0-a985-732f0b9c4ccf)
