### PR TITLE
Fix incorrect closed string enum rendering in bsp4s

### DIFF
--- a/codegen/src/main/scala/bsp/codegen/bsp4s/ScalaRenderer.scala
+++ b/codegen/src/main/scala/bsp/codegen/bsp4s/ScalaRenderer.scala
@@ -228,7 +228,7 @@ class ScalaRenderer(basepkg: String, definitions: List[Def], version: String) {
           s"case object ${toUpperCamelCase(ev.name)} extends ${shapeId.getName}(${ev.value})"
       case StringEnum =>
         (ev: EnumValue[String]) =>
-          s"""case object ${ev.name} extends ${toUpperCamelCase(shapeId.getName)}("${ev.value}")"""
+          s"""case object ${toUpperCamelCase(ev.name)} extends ${shapeId.getName}("${ev.value}")"""
     }
   }
 


### PR DESCRIPTION
Fortunately we currently don't have closed string enums in the spec, so it doesn't change the generated code