### PR TITLE
Fix "scala-test-suites" and "scala-test-suites-selection" data kinds

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/DebugSessionParamsDataKind.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/DebugSessionParamsDataKind.java
@@ -3,6 +3,4 @@ package ch.epfl.scala.bsp4j;
 public class DebugSessionParamsDataKind {
     public static final String SCALA_ATTACH_REMOTE = "scala-attach-remote";
     public static final String SCALA_MAIN_CLASS = "scala-main-class";
-    public static final String SCALA_TEST_SUITES = "scala-test-suites";
-    public static final String SCALA_TEST_SUITES_SELECTION = "scala-test-suites-selection";
 }

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/TestParamsDataKind.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/TestParamsDataKind.java
@@ -2,4 +2,6 @@ package ch.epfl.scala.bsp4j;
 
 public class TestParamsDataKind {
     public static final String SCALA_TEST = "scala-test";
+    public static final String SCALA_TEST_SUITES = "scala-test-suites";
+    public static final String SCALA_TEST_SUITES_SELECTION = "scala-test-suites-selection";
 }

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -320,8 +320,6 @@ object DebugSessionParams {
 object DebugSessionParamsDataKind {
   val ScalaAttachRemote = "scala-attach-remote"
   val ScalaMainClass = "scala-main-class"
-  val ScalaTestSuites = "scala-test-suites"
-  val ScalaTestSuitesSelection = "scala-test-suites-selection"
 }
 
 final case class DependencyModule(
@@ -1269,6 +1267,8 @@ object TestParams {
 
 object TestParamsDataKind {
   val ScalaTest = "scala-test"
+  val ScalaTestSuites = "scala-test-suites"
+  val ScalaTestSuitesSelection = "scala-test-suites-selection"
 }
 
 final case class TestProvider(

--- a/spec/src/main/resources/META-INF/smithy/bsp/extensions/scala.smithy
+++ b/spec/src/main/resources/META-INF/smithy/bsp/extensions/scala.smithy
@@ -10,6 +10,7 @@ use bsp#DebugSessionParamsData
 use bsp#DiagnosticData
 use bsp#Range
 use bsp#RunParamsData
+use bsp#TestParams
 use bsp#TestParamsData
 use bsp#URIs
 use bsp.jvm#Classpath
@@ -253,7 +254,7 @@ list EnvironmentVariablesList {
 }
 
 /// Each element of this array is a fully qualified class name.
-@dataKind(kind: "scala-test-suites", extends: [DebugSessionParamsData])
+@dataKind(kind: "scala-test-suites", extends: [TestParamsData])
 list ScalaTestSuiteClasses {
     member: String
 }
@@ -263,7 +264,7 @@ list ScalaTestSuiteClasses {
 structure ScalaAttachRemote {
 }
 
-@dataKind(kind: "scala-test-suites-selection", extends: [DebugSessionParamsData])
+@dataKind(kind: "scala-test-suites-selection", extends: [TestParamsData])
 structure ScalaTestSuites {
     /// The fully qualified names of the test classes in this target and the tests in this test classes
     @required

--- a/website/generated/docs/extensions/scala.md
+++ b/website/generated/docs/extensions/scala.md
@@ -230,54 +230,6 @@ This structure is embedded in
 the `data?: DebugSessionParamsData` field, when
 the `dataKind` field contains `"scala-main-class"`.
 
-### ScalaTestSuiteClasses
-
-This structure is embedded in
-the `data?: DebugSessionParamsData` field, when
-the `dataKind` field contains `"scala-test-suites"`.
-
-#### ScalaTestSuiteClasses
-
-Each element of this array is a fully qualified class name.
-
-```ts
-export type ScalaTestSuiteClasses = string[];
-```
-
-### ScalaTestSuites
-
-This structure is embedded in
-the `data?: DebugSessionParamsData` field, when
-the `dataKind` field contains `"scala-test-suites-selection"`.
-
-#### ScalaTestSuites
-
-```ts
-export interface ScalaTestSuites {
-  /** The fully qualified names of the test classes in this target and the tests in this test classes */
-  suites: ScalaTestSuiteSelection[];
-
-  /** Additional jvmOptions which will be passed to the forked JVM */
-  jvmOptions: string[];
-
-  /** Enviroment variables should be an array of strings in format KEY=VALUE */
-  environmentVariables: string[];
-}
-```
-
-#### ScalaTestSuiteSelection
-
-```ts
-export interface ScalaTestSuiteSelection {
-  /** Fully qualified name of the test suite class */
-  className: string;
-
-  /** List of tests which should be run within this test suite.
-   * Empty collection means that all of them are supposed to be executed. */
-  tests: string[];
-}
-```
-
 ## BuildTargetData kinds
 
 ### ScalaBuildTarget
@@ -415,5 +367,53 @@ export interface ScalaTestParams {
   /** The JVM options to run tests with. They replace any options
    * that are defined by the build server if defined. */
   jvmOptions?: string[];
+}
+```
+
+### ScalaTestSuiteClasses
+
+This structure is embedded in
+the `data?: TestParamsData` field, when
+the `dataKind` field contains `"scala-test-suites"`.
+
+#### ScalaTestSuiteClasses
+
+Each element of this array is a fully qualified class name.
+
+```ts
+export type ScalaTestSuiteClasses = string[];
+```
+
+### ScalaTestSuites
+
+This structure is embedded in
+the `data?: TestParamsData` field, when
+the `dataKind` field contains `"scala-test-suites-selection"`.
+
+#### ScalaTestSuites
+
+```ts
+export interface ScalaTestSuites {
+  /** The fully qualified names of the test classes in this target and the tests in this test classes */
+  suites: ScalaTestSuiteSelection[];
+
+  /** Additional jvmOptions which will be passed to the forked JVM */
+  jvmOptions: string[];
+
+  /** Enviroment variables should be an array of strings in format KEY=VALUE */
+  environmentVariables: string[];
+}
+```
+
+#### ScalaTestSuiteSelection
+
+```ts
+export interface ScalaTestSuiteSelection {
+  /** Fully qualified name of the test suite class */
+  className: string;
+
+  /** List of tests which should be run within this test suite.
+   * Empty collection means that all of them are supposed to be executed. */
+  tests: string[];
 }
 ```

--- a/website/generated/docs/specification.md
+++ b/website/generated/docs/specification.md
@@ -1114,6 +1114,12 @@ export type TestParamsDataKind = string;
 export namespace TestParamsDataKind {
   /** `data` field must contain a ScalaTestParams object. */
   export const ScalaTest = "scala-test";
+
+  /** `data` field must contain a ScalaTestSuiteClasses object. */
+  export const ScalaTestSuites = "scala-test-suites";
+
+  /** `data` field must contain a ScalaTestSuites object. */
+  export const ScalaTestSuitesSelection = "scala-test-suites-selection";
 }
 ```
 
@@ -1193,12 +1199,6 @@ export namespace DebugSessionParamsDataKind {
 
   /** `data` field must contain a ScalaMainClass object. */
   export const ScalaMainClass = "scala-main-class";
-
-  /** `data` field must contain a ScalaTestSuiteClasses object. */
-  export const ScalaTestSuites = "scala-test-suites";
-
-  /** `data` field must contain a ScalaTestSuites object. */
-  export const ScalaTestSuitesSelection = "scala-test-suites-selection";
 }
 ```
 


### PR DESCRIPTION
They were previously mistakenly marked as debug data kinds