### PR TITLE
`javaVersion` doc in `JvmBuildTarget` includes javac `-target` flag

### DIFF
--- a/spec/src/main/resources/META-INF/smithy/bsp/extensions/jvm.smithy
+++ b/spec/src/main/resources/META-INF/smithy/bsp/extensions/jvm.smithy
@@ -28,7 +28,7 @@ structure JvmBuildTarget {
     /// Uri representing absolute path to jdk
     /// For example: file:///usr/lib/jvm/java-8-openjdk-amd64
     javaHome: URI
-    /// The java version this target is supposed to use.
+    /// The java version this target is supposed to use (can be set using javac `-target` flag).
     /// For example: 1.8
     javaVersion: String
 }

--- a/website/generated/docs/extensions/jvm.md
+++ b/website/generated/docs/extensions/jvm.md
@@ -120,7 +120,7 @@ export interface JvmBuildTarget {
    * For example: file:///usr/lib/jvm/java-8-openjdk-amd64 */
   javaHome?: URI;
 
-  /** The java version this target is supposed to use.
+  /** The java version this target is supposed to use (can be set using javac `-target` flag).
    * For example: 1.8 */
   javaVersion?: string;
 }


### PR DESCRIPTION
hi,

one small (but important) change in the docs for `JvmBuildTarget` - imo it's the way how it should be used, or maybe I'm missing something here?