### PR TITLE
improvement: Add client capability for jvmCompileClasspathProvider

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildClientCapabilities.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildClientCapabilities.java
@@ -11,6 +11,8 @@ public class BuildClientCapabilities {
   @NonNull
   private List<String> languageIds;
 
+  private Boolean jvmCompileClasspathReceiver;
+
   public BuildClientCapabilities(@NonNull final List<String> languageIds) {
     this.languageIds = languageIds;
   }
@@ -25,11 +27,21 @@ public class BuildClientCapabilities {
     this.languageIds = Preconditions.checkNotNull(languageIds, "languageIds");
   }
 
+  @Pure
+  public Boolean getJvmCompileClasspathReceiver() {
+    return this.jvmCompileClasspathReceiver;
+  }
+
+  public void setJvmCompileClasspathReceiver(final Boolean jvmCompileClasspathReceiver) {
+    this.jvmCompileClasspathReceiver = jvmCompileClasspathReceiver;
+  }
+
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("languageIds", this.languageIds);
+    b.add("jvmCompileClasspathReceiver", this.jvmCompileClasspathReceiver);
     return b.toString();
   }
 
@@ -48,12 +60,20 @@ public class BuildClientCapabilities {
         return false;
     } else if (!this.languageIds.equals(other.languageIds))
       return false;
+    if (this.jvmCompileClasspathReceiver == null) {
+      if (other.jvmCompileClasspathReceiver != null)
+        return false;
+    } else if (!this.jvmCompileClasspathReceiver.equals(other.jvmCompileClasspathReceiver))
+      return false;
     return true;
   }
 
   @Override
   @Pure
   public int hashCode() {
-    return 31 * 1 + ((this.languageIds== null) ? 0 : this.languageIds.hashCode());
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.languageIds== null) ? 0 : this.languageIds.hashCode());
+    return prime * result + ((this.jvmCompileClasspathReceiver== null) ? 0 : this.jvmCompileClasspathReceiver.hashCode());
   }
 }

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -56,7 +56,8 @@ object BspConnectionDetails {
 }
 
 final case class BuildClientCapabilities(
-    languageIds: List[String]
+    languageIds: List[String],
+    jvmCompileClasspathReceiver: Option[Boolean]
 )
 
 object BuildClientCapabilities {

--- a/spec/src/main/resources/META-INF/smithy/bsp/bsp.smithy
+++ b/spec/src/main/resources/META-INF/smithy/bsp/bsp.smithy
@@ -554,7 +554,11 @@ structure BuildClientCapabilities {
     /// The server must never respond with build targets for other
     /// languages than those that appear in this list.
     @required
-    languageIds: LanguageIds
+    languageIds: LanguageIds    
+    /// Mirror capability to BuildServerCapabilities.jvmCompileClasspathProvider
+    /// The client will request classpath via `buildTarget/jvmCompileClasspath` so
+    /// it's safe to return classpath in ScalacOptionsItem empty.
+    jvmCompileClasspathReceiver: Boolean = false
 }
 
 /// Language IDs are defined here

--- a/website/generated/docs/specification.md
+++ b/website/generated/docs/specification.md
@@ -422,6 +422,11 @@ export interface BuildClientCapabilities {
    * The server must never respond with build targets for other
    * languages than those that appear in this list. */
   languageIds: LanguageId[];
+
+  /** Mirror capability to BuildServerCapabilities.jvmCompileClasspathProvider
+   * The client will request classpath via `buildTarget/jvmCompileClasspath` so
+   * it's safe to return classpath in ScalacOptionsItem empty. */
+  jvmCompileClasspathReceiver?: boolean;
 }
 ```
 


### PR DESCRIPTION
We can use this to make server aware if it's safe to deprecate the classpath in ScalacOptionsItem