### PR TITLE
bugfix: Add buildTarget/jvmCompileClasspath to JvmBuildServer and Scala's Endpoints

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/JvmBuildServer.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/JvmBuildServer.java
@@ -26,5 +26,12 @@ public interface JvmBuildServer {
     @JsonRequest("buildTarget/jvmRunEnvironment")
     CompletableFuture<JvmRunEnvironmentResult> buildTargetJvmRunEnvironment(JvmRunEnvironmentParams params);
 
+    /**
+     * The build target classpath request is sent from the client to the server to
+     * query the target for its compile classpath.
+     */
+    @JsonRequest("buildTarget/jvmCompileClasspath")
+    CompletableFuture<JvmCompileClasspathResult> buildTargetJvmCompileClasspath(JvmCompileClasspathParams params);
+
 
 }

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
@@ -286,6 +286,14 @@ trait BuildTarget {
         "buildTarget/jvmRunEnvironment"
       )
 
+  /** The build target classpath request is sent from the client to the server to query the target
+    * for its compile classpath.
+    */
+  object jvmCompileClasspath
+      extends Endpoint[JvmCompileClasspathParams, JvmCompileClasspathResult](
+        "buildTarget/jvmCompileClasspath"
+      )
+
   /** The Python Options Request is sent from the client to the server to query for the list of the
     * interpreter flags used to run a given list of targets.
     */

--- a/spec/src/main/resources/META-INF/smithy/bsp/extensions/jvm.smithy
+++ b/spec/src/main/resources/META-INF/smithy/bsp/extensions/jvm.smithy
@@ -17,7 +17,8 @@ use traits#jsonRequest
 service JvmBuildServer {
     operations: [
         BuildTargetJvmTestEnvironment,
-        BuildTargetJvmRunEnvironment
+        BuildTargetJvmRunEnvironment,
+        BuildTargetJvmCompileClasspath
     ]
 }
 

--- a/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
+++ b/testkit/src/main/scala/ch/epfl/scala/bsp/testkit/mock/HappyMockServer.scala
@@ -56,6 +56,7 @@ class HappyMockServer(base: File) extends AbstractMockServer {
     c.setJvmTestEnvironmentProvider(true)
     c.setCanReload(true)
     c.setDependencyModulesProvider(true)
+    c.setJvmCompileClasspathProvider(true)
     c
   }
 
@@ -168,6 +169,16 @@ class HappyMockServer(base: File) extends AbstractMockServer {
     handleRequest {
       val item1: JvmEnvironmentItem = environmentItem(testing = true)
       val result = new JvmTestEnvironmentResult(List(item1).asJava)
+      Right(result)
+    }
+
+  override def buildTargetJvmCompileClasspath(
+      params: JvmCompileClasspathParams
+  ): CompletableFuture[JvmCompileClasspathResult] =
+    handleRequest {
+      val classpath = List("scala-library.jar").asJava
+      val item1: JvmCompileClasspathItem = new JvmCompileClasspathItem(targetId1, classpath)
+      val result = new JvmCompileClasspathResult(List(item1).asJava)
       Right(result)
     }
 

--- a/website/generated/docs/extensions/jvm.md
+++ b/website/generated/docs/extensions/jvm.md
@@ -101,6 +101,45 @@ export interface JvmRunEnvironmentResult {
 }
 ```
 
+### BuildTargetJvmCompileClasspath: request
+
+The build target classpath request is sent from the client to the server to
+query the target for its compile classpath.
+
+- method: `buildTarget/jvmCompileClasspath`
+- params: `JvmCompileClasspathParams`
+- result: `JvmCompileClasspathResult`
+
+#### JvmCompileClasspathParams
+
+```ts
+export interface JvmCompileClasspathParams {
+  targets: BuildTargetIdentifier[];
+}
+```
+
+#### JvmCompileClasspathResult
+
+```ts
+export interface JvmCompileClasspathResult {
+  items: JvmCompileClasspathItem[];
+}
+```
+
+#### JvmCompileClasspathItem
+
+```ts
+export interface JvmCompileClasspathItem {
+  target: BuildTargetIdentifier;
+
+  /** The dependency classpath for this target, must be
+   * identical to what is passed as arguments to
+   * the -classpath flag in the command line interface
+   * of scalac. */
+  classpath: string[];
+}
+```
+
 ## BuildTargetData kinds
 
 ### JvmBuildTarget


### PR DESCRIPTION
It doesn't seem to be added by smithy, which I missed.