### PR TITLE
Split docs publishing and releasing artifacts to maven

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,44 @@
+name: Publish docs
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Mount bazel cache
+        uses: actions/cache@v4
+        with:
+          path: '/home/runner/.cache/bazel'
+          key: bazel
+          save-always: true
+      - name: Generate docs
+        run: bazel run //website:docusaurus-build
+      - name: Upload Build Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: bazel-bin/website/docusaurus-build_/docusaurus-build.runfiles/_main/website/build
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: publish
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+env:
+  GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}
+  GIT_USER: build-server-protocol@build-server-protocol.github.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 on:
   push:
-    branches: [master]
     tags: ["*"]
   workflow_dispatch:
 jobs:
@@ -21,12 +20,6 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.PGP_SECRET }}
           passphrase: ${{ secrets.PGP_PASSPHRASE }}
-      - name: Generate docs
-        run: bazel run //website:docusaurus-build
-      - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: bazel-out/k8-fastbuild/bin/website/docusaurus-build.sh.runfiles/_main/website/build
       - name: Publish bsp4j artifacts
         run: |
           bazel run \
@@ -41,24 +34,6 @@ jobs:
               --define "maven_user=$MAVEN_USER" \
               --define "maven_password=$MAVEN_PASSWORD" \
               //bsp4s:bsp4s.publish
-  deploy:
-    name: Deploy to GitHub Pages
-    needs: publish
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    permissions:
-      pages: write # to deploy to Pages
-      id-token: write # to verify the deployment originates from an appropriate source
-    # Deploy to the github-pages environment
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
 env:
-  GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}
-  GIT_USER: build-server-protocol@build-server-protocol.github.io
   MAVEN_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
   MAVEN_USER: ${{ secrets.SONATYPE_USERNAME }}


### PR DESCRIPTION
Artifacts should be released only when a new tag is marked, docs should be published on every push to master.